### PR TITLE
fix(ui): Stop double-labeling Checkbox

### DIFF
--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckboxButton,
-  CheckboxField,
-  type CheckboxFieldProps,
-  Label,
-} from "react-aria-components";
+import { CheckboxButton, CheckboxField, type CheckboxFieldProps } from "react-aria-components";
 
 import { cx } from "#/lib/cva.ts";
 
@@ -32,16 +27,23 @@ interface Props extends CheckboxFieldProps {
   children?: React.ReactNode;
 }
 
+/**
+ * `CheckboxButton` renders as the `<label>` for the hidden input — its
+ * children ARE the label, box + text together. A separate `<Label>` next to
+ * it double-labels the control (RAC Checkbox docs show only this shape, no
+ * sibling `Label`).
+ */
 export function Checkbox({ className, children, ...props }: Props) {
   return (
-    <CheckboxField
-      className={cx("inline-flex items-center gap-2 data-disabled:opacity-50", className)}
-      {...props}
-    >
-      <CheckboxButton className="group border-subtle data-selected:border-accent data-selected:bg-accent data-focus-visible:ring-accent flex size-5 items-center justify-center rounded border transition-colors outline-none data-focus-visible:ring-2">
-        <CheckMark />
+    <CheckboxField {...props}>
+      <CheckboxButton
+        className={cx("group inline-flex items-center gap-2 data-disabled:opacity-50", className)}
+      >
+        <span className="border-subtle group-data-selected:border-accent group-data-selected:bg-accent group-data-focus-visible:ring-accent flex size-5 shrink-0 items-center justify-center rounded border transition-colors outline-none group-data-focus-visible:ring-2">
+          <CheckMark />
+        </span>
+        {children && <span className="text-app select-none">{children}</span>}
       </CheckboxButton>
-      {children && <Label className="text-app select-none">{children}</Label>}
     </CheckboxField>
   );
 }


### PR DESCRIPTION
## Summary
- `CheckboxButton` already renders as the `<label>` for the hidden input — the official RAC pattern puts box + text as its children, no sibling `Label`.
- Our `Checkbox` wrapper put the visible text in a separate `<Label>` next to the box, so the control ended up with two labeling elements.
- Moved box + text inside `CheckboxButton` as plain spans, styled via `group-data-*` since `CheckboxButton` itself now carries the selected/focus/disabled state.

Verified manually against `/login`'s "Angemeldet bleiben" checkbox (the only usage with a visible label); `pnpm --filter web typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)