### PR TITLE
Unify Archiv visibility on published, not completed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Shared documentation in `docs/`:
 - `tokens.md` — Design tokens: breakpoints, easing, shadows, border-radius, typography scale
 - `deployment.md` — Environment variables, first-deploy bootstrap, user management
 - `web-shell.md` — Public shell: header contents, nav strategy, planned docked/drawer chat panel
-- `color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm, SSR constraint (specced, not built)
+- `color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm, SSR constraint
 - `archiv.md` — Archiv feature: ranking columns on `players`, dashboard entry (built — `/archiv`, `/archiv/:slug`)
 - `championship-scope-plan.md` — Championship as a URL dimension so Archiv and current-season views share route files; dashboard becomes the shared championship overview (designed, not started)
 - `chat-plan.md` — Planned in-app chat: separate DB, phased transport (polling → SSE/WS on Railway), TanStack Virtual (not yet built)

--- a/apps/web/app/lib/archiv.server.ts
+++ b/apps/web/app/lib/archiv.server.ts
@@ -88,16 +88,24 @@ export async function getArchivChampionshipBySlug(slug: string) {
   return (await db.query.championships.findFirst({ where: { slug, published: true } })) ?? null;
 }
 
-/** Nearest lower/higher completed championship by nr — null at the ends. */
+/**
+ * Nearest lower/higher published championship by nr — null at the ends.
+ *
+ * `published`, not `completed` — same visibility rule as
+ * `getArchivChampionshipBySlug`. Filtering on `completed` here would break
+ * the chain asymmetrically: the still-running championship stays reachable
+ * by slug (published), so Prev could step off of it, but Next could never
+ * step back onto it.
+ */
 export async function getAdjacentArchivChampionships(nr: number) {
   const [prev, next] = await Promise.all([
     db.query.championships.findFirst({
-      where: { nr: { lt: nr }, completed: true },
+      where: { nr: { lt: nr }, published: true },
       orderBy: { nr: "desc" },
       columns: { slug: true, name: true },
     }),
     db.query.championships.findFirst({
-      where: { nr: { gt: nr }, completed: true },
+      where: { nr: { gt: nr }, published: true },
       orderBy: { nr: "asc" },
       columns: { slug: true, name: true },
     }),

--- a/apps/web/app/lib/archiv.server.ts
+++ b/apps/web/app/lib/archiv.server.ts
@@ -14,26 +14,34 @@ function groupWinners<T extends { championshipId: number }>(rows: T[]) {
   return byChampionship;
 }
 
-/** Every completed championship with its winner(s) — the archiv index list. */
-export async function getAllCompletedChampionships() {
-  const allCompleted = await db.query.championships.findMany({
-    where: { completed: true },
+/**
+ * Every published championship — the archiv index list. Completed ones carry
+ * their winner(s); the still-running one (if any) has none yet, since `rank`
+ * is live-updated all season and would otherwise read as a false "winner".
+ */
+export async function getArchivChampionshipList() {
+  const all = await db.query.championships.findMany({
+    where: { published: true },
     orderBy: { nr: "desc" },
-    columns: { id: true, slug: true, name: true },
+    columns: { id: true, slug: true, name: true, completed: true },
   });
-  if (allCompleted.length === 0) return [];
+  if (all.length === 0) return [];
 
-  const winners = await db.query.players.findMany({
-    where: { rank: 1, championshipId: { in: allCompleted.map((c) => c.id) } },
-    columns: { championshipId: true, total: true },
-    with: { user: { columns: { name: true, slug: true } } },
-  });
+  const completedIds = all.filter((c) => c.completed).map((c) => c.id);
+  const winners = completedIds.length
+    ? await db.query.players.findMany({
+        where: { rank: 1, championshipId: { in: completedIds } },
+        columns: { championshipId: true, total: true },
+        with: { user: { columns: { name: true, slug: true } } },
+      })
+    : [];
 
   const winnersByChampionship = groupWinners(winners);
 
-  return allCompleted.map((c) => ({
+  return all.map((c) => ({
     slug: c.slug,
     name: c.name,
+    completed: c.completed,
     winners: (winnersByChampionship.get(c.id) ?? []).map((w) => ({
       name: w.user.name,
       slug: w.user.slug,
@@ -42,7 +50,12 @@ export async function getAllCompletedChampionships() {
   }));
 }
 
-/** All-time standings across completed championships. */
+/**
+ * All-time standings across every published championship, including the
+ * still-running one — its provisional totals count already, same as any
+ * "ewige Tabelle" that updates through the current season rather than only
+ * after it ends.
+ */
 export async function getEwigeTabelle() {
   const rows = await db
     .select({
@@ -54,7 +67,7 @@ export async function getEwigeTabelle() {
     .from(players)
     .innerJoin(championships, eq(players.championshipId, championships.id))
     .innerJoin(users, eq(players.userId, users.id))
-    .where(eq(championships.completed, true))
+    .where(eq(championships.published, true))
     .groupBy(players.userId);
 
   const sorted = rows

--- a/apps/web/app/routes/public/archiv/index.tsx
+++ b/apps/web/app/routes/public/archiv/index.tsx
@@ -1,11 +1,11 @@
 import { CellLink } from "#/components/cell-link.tsx";
-import { getAllCompletedChampionships, getEwigeTabelle } from "#/lib/archiv.server.ts";
+import { getArchivChampionshipList, getEwigeTabelle } from "#/lib/archiv.server.ts";
 
 import type { Route } from "./+types/index";
 
 export async function loader(_: Route.LoaderArgs) {
   const [championships, entries] = await Promise.all([
-    getAllCompletedChampionships(),
+    getArchivChampionshipList(),
     getEwigeTabelle(),
   ]);
 
@@ -26,7 +26,7 @@ export default function Archiv({ loaderData }: Route.ComponentProps) {
         <section>
           <h2 className="text-muted mb-3 text-xs font-medium tracking-wide uppercase">Turniere</h2>
           {championships.length === 0 ? (
-            <p className="text-subtle text-base">Noch keine abgeschlossenen Turniere.</p>
+            <p className="text-subtle text-base">Noch keine Turniere.</p>
           ) : (
             <table className="w-full text-base">
               <thead>
@@ -43,12 +43,16 @@ export default function Archiv({ loaderData }: Route.ComponentProps) {
                       <CellLink href={`/archiv/${entry.slug}`}>{entry.name}</CellLink>
                     </td>
                     <td className="py-2 pr-3">
-                      {entry.winners.map((w, i) => (
-                        <span key={w.slug}>
-                          {i > 0 && ", "}
-                          {w.name}
-                        </span>
-                      ))}
+                      {entry.completed ? (
+                        entry.winners.map((w, i) => (
+                          <span key={w.slug}>
+                            {i > 0 && ", "}
+                            {w.name}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-subtle italic">(laufend)</span>
+                      )}
                     </td>
                     <td className="py-2 text-right font-medium tabular-nums">
                       {entry.winners[0]?.total ?? "–"}

--- a/docs/chat-plan.md
+++ b/docs/chat-plan.md
@@ -1,6 +1,6 @@
 # In-App Chat — Plan
 
-**Status: planned, not started.** Picks up after the pending rule changes land.
+**Status: planned, not started.**
 This doc records the architecture decisions and reasoning from the 2026-07
 discussion so the feature can start without re-deriving them.
 


### PR DESCRIPTION
## Summary
Three commits, same root cause: leftover `completed` filters from before the published/completed visibility split ([championship-scope-plan.md](../blob/main/docs/championship-scope-plan.md)) that `getArchivChampionshipBySlug` already followed but a few siblings hadn't caught up to.

1. **fix:** `getAdjacentArchivChampionships` filtered Prev/Next on `completed`, while the detail route it feeds resolves by `published` — so the running championship was reachable by slug but not by Next, an asymmetric dead end once you stepped off it via Prev.
2. **feat:** Archiv list and Ewige Tabelle also filtered on `completed`, so the running championship was invisible in both — even though its own detail page was already reachable. Ewige Tabelle now counts its provisional points too, same as how a real "ewige Tabelle" (e.g. the Bundesliga's) already counts the current season.
3. **docs:** two small unrelated staleness fixes noticed along the way.

Verified manually against the dev DB (EM 2004 running, 4 completed seasons); `pnpm --filter web typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)