### PR TITLE
feat(web): Link Zusatzpunkte column header to Zusatzfragen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.27.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v0.26.2...v0.27.0)
+
+### 🚀 Enhancements
+
+- **web:** Include the running championship in Archiv list and Ewige Tabelle ([16e2ef6](https://github.com/haus23/tipprunde/commit/16e2ef6))
+- **web:** Link the Zusatzpunkte column header to Zusatzfragen ([43ea668](https://github.com/haus23/tipprunde/commit/43ea668))
+
+### 🩹 Fixes
+
+- **ui:** Stop double-labeling Checkbox ([95b49be](https://github.com/haus23/tipprunde/commit/95b49be))
+- **web:** Fix asymmetric Prev/Next chain in the Archiv ([36657e5](https://github.com/haus23/tipprunde/commit/36657e5))
+- **web:** Give the Zusatzpunkte header link a star icon ([5ac5fb0](https://github.com/haus23/tipprunde/commit/5ac5fb0))
+
+### 📖 Documentation
+
+- Note color-scheme is built, drop stale chat-plan dependency note ([00705bc](https://github.com/haus23/tipprunde/commit/00705bc))
+
 ## v0.26.2
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v0.26.1...v0.26.2)

--- a/apps/web/app/components/ranking-table.tsx
+++ b/apps/web/app/components/ranking-table.tsx
@@ -38,8 +38,10 @@ export function RankingTable({
           </th>
           {showExtras && (
             <th className="border-subtle xs:px-3 xs:py-2.5 w-px border-b px-2 py-2 text-center font-medium">
-              <span className="xs:inline hidden">Zusatzpunkte</span>
-              <span className="xs:hidden">Zusatzpkt.</span>
+              <CellLink href={scoped("/zusatzfragen")}>
+                <span className="xs:inline hidden">Zusatzpunkte</span>
+                <span className="xs:hidden">Zusatzpkt.</span>
+              </CellLink>
             </th>
           )}
           <th className="border-subtle xs:px-3 xs:py-2.5 w-px border-b px-2 py-2 text-center font-medium">

--- a/apps/web/app/components/ranking-table.tsx
+++ b/apps/web/app/components/ranking-table.tsx
@@ -39,7 +39,10 @@ export function RankingTable({
           {showExtras && (
             <th className="border-subtle xs:px-3 xs:py-2.5 w-px border-b px-2 py-2 text-center font-medium">
               <CellLink href={scoped("/zusatzfragen")}>
-                <span className="xs:inline hidden">Zusatzpunkte</span>
+                <span className="xs:inline-flex hidden items-center gap-1">
+                  <StarIcon className="size-3.5 shrink-0" />
+                  Zusatzpunkte
+                </span>
                 <span className="xs:hidden">Zusatzpkt.</span>
               </CellLink>
             </th>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
The ranking table's Zusatzpunkte column header now links to `/zusatzfragen` (scoped, works in both the current championship and the Archiv) — the idea recorded in [championship-scope-plan.md](../blob/main/docs/championship-scope-plan.md#secondary-content-routes-not-modals) ("Additional entry point for Zusatzfragen").

Checked the other column headers (Platz, Spieler, Gesamtpunkte, the Aktuelle-Tipps icon column) — none has a sensible single link target: Spieler already links per-row, Gesamtpunkte is already served by the "Vollständige Tabelle →" link, the rest have no natural target.

Verified manually on `/archiv/rr0304/tabelle` — link resolves to `/archiv/rr0304/zusatzfragen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)