### PR TITLE
Small UI alignment fixes: Zusatzpunkte header baseline + UserArea height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.27.1
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v0.27.0...v0.27.1)
+
+### 🩹 Fixes
+
+- **web:** Fix baseline shift on the Zusatzpunkte header icon ([429494b](https://github.com/haus23/tipprunde/commit/429494b))
+- **web:** Give UserArea a fixed height matching the theme toggle ([9b372e6](https://github.com/haus23/tipprunde/commit/9b372e6))
+
 ## v0.27.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v0.26.2...v0.27.0)

--- a/apps/web/app/components/ranking-table.tsx
+++ b/apps/web/app/components/ranking-table.tsx
@@ -39,8 +39,8 @@ export function RankingTable({
           {showExtras && (
             <th className="border-subtle xs:px-3 xs:py-2.5 w-px border-b px-2 py-2 text-center font-medium">
               <CellLink href={scoped("/zusatzfragen")}>
-                <span className="xs:inline-flex hidden items-center gap-1">
-                  <StarIcon className="size-3.5 shrink-0" />
+                <span className="xs:inline-flex hidden items-baseline gap-1">
+                  <StarIcon className="relative top-[0.1em] size-3.5 shrink-0" />
                   Zusatzpunkte
                 </span>
                 <span className="xs:hidden">Zusatzpkt.</span>

--- a/apps/web/app/routes/public/_user-area.tsx
+++ b/apps/web/app/routes/public/_user-area.tsx
@@ -15,7 +15,7 @@ export function UserArea({ user }: { user: User | null }) {
     return (
       <Link
         to="/login"
-        className="text-muted hover:bg-nav-active hover:text-app focus-visible:ring-accent flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm transition ease-out outline-none focus-visible:ring-2 max-sm:px-1.5"
+        className="text-muted hover:bg-nav-active hover:text-app focus-visible:ring-accent flex h-7 items-center gap-2 rounded-sm px-3 py-1.5 text-sm transition ease-out outline-none focus-visible:ring-2 max-sm:px-1.5"
       >
         <span className="max-sm:sr-only">Anmelden</span>
         <LogInIcon className="size-4" />
@@ -27,7 +27,7 @@ export function UserArea({ user }: { user: User | null }) {
   if (user.role === "user") {
     return (
       <Form method="post" action="/logout">
-        <Button type="submit" intent="ghost" size="sm" className="max-sm:px-1.5">
+        <Button type="submit" intent="ghost" size="sm" className="h-7 max-sm:px-1.5">
           <span className="max-sm:sr-only">Abmelden</span>
           <LogOutIcon className="size-4" />
         </Button>
@@ -37,7 +37,7 @@ export function UserArea({ user }: { user: User | null }) {
 
   return (
     <MenuTrigger>
-      <Button intent="ghost" size="sm" className="max-sm:px-1.5">
+      <Button intent="ghost" size="sm" className="h-7 max-sm:px-1.5">
         <span className="max-sm:sr-only">{user.name}</span>
         <ChevronDownIcon className="size-4" />
       </Button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Two small, unrelated visual polish fixes bundled on one branch:

1. **Zusatzpunkte header baseline shift** — the icon+text flex wrapper on the new Zusatzpunkte column header link centered on content metrics (14px icon vs. text's own line-height) instead of the line-height-based centering the plain-text sibling headers get, a ~1.25px vertical shift. Switched to `items-baseline` + a small icon nudge.
2. **UserArea height inconsistent with the theme toggle** — at icon-only width both matched by coincidence; once the `sm:` breakpoint reveals the label text, the button grew taller than the always-icon-only theme toggle (flex row height was content-driven, text line-height > icon height). Fixed with an explicit `h-7` matching the icon-only height.

Both verified manually via DOM measurements (text-node bounding rects / button heights at multiple viewport widths) before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)