### PR TITLE
feat: Punkteverlauf as a bump chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## v0.28.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v0.27.1...v0.28.0)
+
+### 🚀 Enhancements
+
+- **domain:** Add calcProgression for the Punkteverlauf ([f833768](https://github.com/haus23/tipprunde/commit/f833768))
+- **web:** Add the Verlauf query module ([23712ad](https://github.com/haus23/tipprunde/commit/23712ad))
+- **web:** Add the Punkteverlauf route and bump chart ([aaadbc7](https://github.com/haus23/tipprunde/commit/aaadbc7))
+- **web:** Add crosshair, readout and focus switching to the Verlauf ([952fde9](https://github.com/haus23/tipprunde/commit/952fde9))
+- **web:** Make the Verlauf keyboard- and screen-reader accessible ([6c1fd2d](https://github.com/haus23/tipprunde/commit/6c1fd2d))
+- **web:** Draw a divider at every round's end, none at the chart's ([d48a2fd](https://github.com/haus23/tipprunde/commit/d48a2fd))
+- **web:** Link a player's Platz to their Verlauf ([4768664](https://github.com/haus23/tipprunde/commit/4768664))
+
+### 🩹 Fixes
+
+- **web:** Let the Verlauf lines transition when the focus moves ([9f762a4](https://github.com/haus23/tipprunde/commit/9f762a4))
+- **web:** Call the view "Verlauf", not "Punkteverlauf" ([9b716b1](https://github.com/haus23/tipprunde/commit/9b716b1))
+- **web:** Size the Verlauf name column to the names, not a fixed 92px ([ed795aa](https://github.com/haus23/tipprunde/commit/ed795aa))
+- **web:** Tighten the Verlauf readout ([beb70aa](https://github.com/haus23/tipprunde/commit/beb70aa))
+- **web:** Put the Verlauf readout in a fixed place, not a floating tooltip ([93e70bf](https://github.com/haus23/tipprunde/commit/93e70bf))
+- **web:** Give the Verlauf link an icon, drop the name from the readout ([4cdeadb](https://github.com/haus23/tipprunde/commit/4cdeadb))
+- **web:** Keep the highlighted player pinned with the readout ([3186cb3](https://github.com/haus23/tipprunde/commit/3186cb3))
+- **web:** Stop the hidden Verlauf table inflating the page height ([e430c16](https://github.com/haus23/tipprunde/commit/e430c16))
+
+### 💅 Refactors
+
+- **web:** Share PlayerSwitch between Tipps and Verlauf ([c95f144](https://github.com/haus23/tipprunde/commit/c95f144))
+- **web:** Rename CellLink to AppLink ([edf5d4a](https://github.com/haus23/tipprunde/commit/edf5d4a))
+- Change chart icon to trending icon. ([12abf91](https://github.com/haus23/tipprunde/commit/12abf91))
+
+### 📖 Documentation
+
+- Design the Punkteverlauf as a bump chart ([1dc5a18](https://github.com/haus23/tipprunde/commit/1dc5a18))
+- Record the Punkteverlauf as built, refresh the public route list ([328ba6e](https://github.com/haus23/tipprunde/commit/328ba6e))
+
 ## v0.27.1
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v0.27.0...v0.27.1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Shared documentation in `docs/`:
 - `color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm, SSR constraint
 - `archiv.md` — Archiv feature: ranking columns on `players`, dashboard entry (built — `/archiv`, `/archiv/:slug`)
 - `championship-scope-plan.md` — Championship as a URL dimension so Archiv and current-season views share route files; dashboard is the shared championship overview (built)
-- `verlauf-plan.md` — Planned Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (designed, not started)
+- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (iteration 1 built)
 - `chat-plan.md` — Planned in-app chat: separate DB, phased transport (polling → SSE/WS on Railway), TanStack Virtual (not yet built)
 - `app-merge.md` — History: how the TanStack Start app merged into the RR8 app (phases A–D, done 2026-08-09); step 1 of merge → Railway → Litestream
 - `railway-plan.md` — **Next up.** Planned prod hosting: single Node service on Railway, SQLite file + Litestream→R2, cost breakdown (steps 2/3)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,8 @@ Shared documentation in `docs/`:
 - `web-shell.md` — Public shell: header contents, nav strategy, planned docked/drawer chat panel
 - `color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm, SSR constraint
 - `archiv.md` — Archiv feature: ranking columns on `players`, dashboard entry (built — `/archiv`, `/archiv/:slug`)
-- `championship-scope-plan.md` — Championship as a URL dimension so Archiv and current-season views share route files; dashboard becomes the shared championship overview (designed, not started)
+- `championship-scope-plan.md` — Championship as a URL dimension so Archiv and current-season views share route files; dashboard is the shared championship overview (built)
+- `verlauf-plan.md` — Planned Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (designed, not started)
 - `chat-plan.md` — Planned in-app chat: separate DB, phased transport (polling → SSE/WS on Railway), TanStack Virtual (not yet built)
 - `app-merge.md` — History: how the TanStack Start app merged into the RR8 app (phases A–D, done 2026-08-09); step 1 of merge → Railway → Litestream
 - `railway-plan.md` — **Next up.** Planned prod hosting: single Node service on Railway, SQLite file + Litestream→R2, cost breakdown (steps 2/3)

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -100,7 +100,8 @@ Shared docs are in the root `docs/` folder:
 - `web-shell.md` — Public shell: header contents, nav strategy, planned chat panel
 - `color-scheme.md` — Single-button light/dark switch spec (replaces both current controls)
 - `archiv.md` — Archiv: the materialized ranking columns on `players` and what depends on them
-- `championship-scope-plan.md` — Public-routing change: championship as a URL dimension, shared route files for Archiv + current season, dashboard as the shared overview (designed, not started)
+- `championship-scope-plan.md` — Public-routing change: championship as a URL dimension, shared route files for Archiv + current season, dashboard as the shared overview (built)
+- `verlauf-plan.md` — Planned Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (designed, not started)
 - `app-merge.md` — History: how this app absorbed the separate web app (why things look the way they do)
 
 ## Environment variables

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -39,12 +39,22 @@ This app reads and writes the DB with drizzle-orm. No drizzle-kit setup here.
 
 Public routes live at the root; the manager sits under `/manager`.
 
-- `/` — Dashboard: standings, current matches, ruleset, Archiv preview
-- `/tabelle` — Current/final table of the published championship
+The championship-scoped views below are mounted **twice** from one set of
+files — at the root for the running championship, and under `/archiv/:slug`
+for any other published one (see `championship-scope-plan.md`):
+
+- `/` — Championship overview: standings, current matches, ruleset
+- `/tabelle` — Current/final table
 - `/spiele`, `/spiele/:nr` — Match overview (accordion) and per-match tips
-- `/tipps/:slug?` — One player's tips (defaults to self, else rank 1)
+- `/tipps/:playerSlug?` — One player's tips (defaults to self, else rank 1)
+- `/verlauf/:playerSlug?` — Rank progression bump chart; the slug only picks
+  the highlighted line (see `verlauf-plan.md`)
 - `/zusatzfragen` — Extra questions and answers
-- `/archiv`, `/archiv/:slug` — Completed championships + all-time table
+- `/regelwerk` — The championship's ruleset in full
+
+Cross-championship, outside that scope:
+
+- `/archiv` — All published championships + all-time table
 - `/login` — TOTP login (two steps, intent-based action)
 - `/color-scheme`, `/logout` — action-only, shared by both shells
 - `/matchday-tips/:userId` — Resource route for the ranking table's popover
@@ -101,7 +111,7 @@ Shared docs are in the root `docs/` folder:
 - `color-scheme.md` — Single-button light/dark switch spec (replaces both current controls)
 - `archiv.md` — Archiv: the materialized ranking columns on `players` and what depends on them
 - `championship-scope-plan.md` — Public-routing change: championship as a URL dimension, shared route files for Archiv + current season, dashboard as the shared overview (built)
-- `verlauf-plan.md` — Planned Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (designed, not started)
+- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (iteration 1 built)
 - `app-merge.md` — History: how this app absorbed the separate web app (why things look the way they do)
 
 ## Environment variables

--- a/apps/web/app/components/app-link.tsx
+++ b/apps/web/app/components/app-link.tsx
@@ -5,15 +5,15 @@ interface Props extends Omit<LinkProps, "className"> {
 }
 
 /**
- * Links a table cell column to its navigation target.
+ * The app's inline text link — in a table cell, in a heading, in prose.
  *
  * Affordance: hover devices highlight on hover; touch devices (no hover) get a
- * persistent underline so linked cells are recognizable. `data-pressed` gives
+ * persistent underline so linked text is recognizable. `data-pressed` gives
  * immediate tap feedback before the (sometimes slow) navigation starts.
  *
  * Client-side routing comes from the RAC RouterProvider wired up in root.
  */
-export function CellLink(props: Props) {
+export function AppLink(props: Props) {
   return (
     <AriaLink
       {...props}

--- a/apps/web/app/components/player-switch.tsx
+++ b/apps/web/app/components/player-switch.tsx
@@ -23,6 +23,12 @@ interface Player {
 interface Props {
   players: Player[];
   currentSlug: string;
+  /**
+   * Championship-relative route the picked player is appended to — `/tipps`
+   * opens their tips, `/verlauf` highlights their line.
+   */
+  basePath: string;
+  label?: string;
 }
 
 /** Diacritic-insensitive contains, so "mu" matches "Müller". */
@@ -37,7 +43,7 @@ const normalize = (s: string) =>
  * opens a command-palette popover (search field + filtered list). Self-contained
  * so the internals can later be swapped for a `cmdk`-based palette.
  */
-export function PlayerSwitch({ players, currentSlug }: Props) {
+export function PlayerSwitch({ players, currentSlug, basePath, label }: Props) {
   const navigate = useNavigate();
   const scoped = useScopedPath();
   const [isOpen, setIsOpen] = useState(false);
@@ -45,7 +51,7 @@ export function PlayerSwitch({ players, currentSlug }: Props) {
   return (
     <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
       <Button
-        aria-label="Spieler wechseln"
+        aria-label={label ?? "Spieler wechseln"}
         className="text-subtle data-hovered:bg-nav-active data-hovered:text-app data-focus-visible:ring-accent flex size-7 items-center justify-center rounded-sm transition ease-out outline-none data-focus-visible:ring-2 data-pressed:scale-[0.97]"
       >
         <ChevronsUpDownIcon className="size-4" />
@@ -76,7 +82,7 @@ export function PlayerSwitch({ players, currentSlug }: Props) {
               className="min-h-0 flex-1 overflow-auto p-1 outline-none"
               onAction={(key) => {
                 setIsOpen(false);
-                void navigate(scoped(`/tipps/${key}`));
+                void navigate(scoped(`${basePath}/${key}`), { preventScrollReset: true });
               }}
             >
               {players.map((p) => (

--- a/apps/web/app/components/ranking-table.tsx
+++ b/apps/web/app/components/ranking-table.tsx
@@ -4,8 +4,8 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Button, Dialog, OverlayArrow, Popover } from "react-aria-components";
 import { useFetcher } from "react-router";
 
+import { AppLink } from "#/components/app-link.tsx";
 import { CellFlag } from "#/components/cell-flag.tsx";
-import { CellLink } from "#/components/cell-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import type { RankedPlayer } from "#/lib/ranking.server.ts";
 import type { MatchdayTip } from "#/lib/spiele.server.ts";
@@ -38,13 +38,13 @@ export function RankingTable({
           </th>
           {showExtras && (
             <th className="border-subtle xs:px-3 xs:py-2.5 w-px border-b px-2 py-2 text-center font-medium">
-              <CellLink href={scoped("/zusatzfragen")}>
+              <AppLink href={scoped("/zusatzfragen")}>
                 <span className="xs:inline-flex hidden items-baseline gap-1">
                   <StarIcon className="relative top-[0.1em] size-3.5 shrink-0" />
                   Zusatzpunkte
                 </span>
                 <span className="xs:hidden">Zusatzpkt.</span>
-              </CellLink>
+              </AppLink>
             </th>
           )}
           <th className="border-subtle xs:px-3 xs:py-2.5 w-px border-b px-2 py-2 text-center font-medium">
@@ -78,7 +78,7 @@ export function RankingTable({
                 {sharesRankAbove ? "" : entry.rank}
               </td>
               <td className={cx("xs:px-3 xs:py-3 px-2 py-2", isCurrentUser && "font-medium")}>
-                <CellLink href={scoped(`/tipps/${entry.slug}`)}>{entry.name}</CellLink>
+                <AppLink href={scoped(`/tipps/${entry.slug}`)}>{entry.name}</AppLink>
               </td>
               {showExtras && (
                 <td className="text-subtle xs:px-3 xs:py-3 px-2 py-2 text-center tabular-nums">
@@ -232,7 +232,7 @@ function MatchdayButton({
                 matches.map((m) => (
                   <tr key={m.nr} className="border-subtle border-b last:border-0">
                     <td className="py-1.5 pr-3">
-                      <CellLink href={scoped(`/spiele/${m.nr}`)}>{m.paarungShort}</CellLink>
+                      <AppLink href={scoped(`/spiele/${m.nr}`)}>{m.paarungShort}</AppLink>
                     </td>
                     <td className="px-2 py-1.5 text-center tabular-nums">
                       <span className="relative">

--- a/apps/web/app/lib/verlauf.server.ts
+++ b/apps/web/app/lib/verlauf.server.ts
@@ -1,0 +1,181 @@
+import {
+  extraAnswers,
+  extraQuestions,
+  matches,
+  roundPoints as roundPointsTable,
+  rounds,
+  tips,
+} from "@tipprunde/db/schema";
+import { calcProgression } from "@tipprunde/domain/progression";
+import { includesExtraQuestions } from "@tipprunde/domain/ranking";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "./db.server.ts";
+
+/**
+ * One position on the chart's x axis. Not a match-number scale: round points
+ * and extra-question points get their own steps, so every point a player ever
+ * scores has a place and the chart ends on the Abschlusstabelle.
+ */
+export type VerlaufStep =
+  | { kind: "match"; nr: number }
+  | { kind: "roundPoints"; roundNr: number }
+  | { kind: "extraPoints" };
+
+export type VerlaufPlayer = {
+  userId: number;
+  name: string;
+  slug: string;
+  /** Display row per played step, 0-based and unique — see calcProgression. */
+  positions: number[];
+  /** Tie-aware rank per played step, 1-based. */
+  ranks: number[];
+  /** Cumulative total per played step. */
+  points: number[];
+};
+
+export type Verlauf = {
+  steps: VerlaufStep[];
+  /** Steps from here on have no data yet; lines stop before them. */
+  playedSteps: number;
+  /** Ordered by final display row, so the right-edge labels never overlap. */
+  players: VerlaufPlayer[];
+};
+
+/**
+ * The full rank progression of a championship, ready to plot.
+ *
+ * Unlike every other public view this aggregates at read time — the
+ * materialized `players` columns only hold end-of-championship totals, never a
+ * per-step history. That is a deliberate, documented exception: the largest
+ * championship is under 900 tip rows, so this is four indexed queries and a
+ * pass over ~1000 gains. See docs/verlauf-plan.md.
+ */
+export async function getVerlauf(championshipId: number): Promise<Verlauf> {
+  const [championship, enrolled, publishedRounds, tipRows, roundPointRows, extraRows] =
+    await Promise.all([
+      db.query.championships.findFirst({
+        where: { id: championshipId },
+        columns: { extraQuestionPointsPublished: true },
+        with: { ruleset: { columns: { extraQuestionRuleId: true } } },
+      }),
+      db.query.players.findMany({
+        where: { championshipId },
+        columns: { userId: true },
+        with: { user: { columns: { name: true, slug: true } } },
+      }),
+      db.query.rounds.findMany({
+        where: { championshipId, published: true },
+        orderBy: { nr: "asc" },
+        columns: { id: true, nr: true },
+        with: {
+          matches: { orderBy: { nr: "asc" }, columns: { id: true, nr: true, result: true } },
+        },
+      }),
+      db
+        .select({ matchId: tips.matchId, userId: tips.userId, points: tips.points })
+        .from(tips)
+        .innerJoin(matches, eq(tips.matchId, matches.id))
+        .innerJoin(rounds, eq(matches.roundId, rounds.id))
+        .where(and(eq(rounds.championshipId, championshipId), eq(rounds.published, true))),
+      db
+        .select({
+          roundId: roundPointsTable.roundId,
+          userId: roundPointsTable.userId,
+          points: roundPointsTable.points,
+        })
+        .from(roundPointsTable)
+        .innerJoin(rounds, eq(roundPointsTable.roundId, rounds.id))
+        .where(and(eq(rounds.championshipId, championshipId), eq(rounds.published, true))),
+      db
+        .select({ userId: extraAnswers.userId, points: extraAnswers.points })
+        .from(extraAnswers)
+        .innerJoin(extraQuestions, eq(extraAnswers.extraQuestionId, extraQuestions.id))
+        .where(eq(extraQuestions.championshipId, championshipId)),
+    ]);
+
+  const players = enrolled.map((p) => ({
+    userId: p.userId,
+    name: p.user?.name ?? "",
+    slug: p.user?.slug ?? "",
+  }));
+
+  if (!championship || players.length === 0) {
+    return { steps: [], playedSteps: 0, players: [] };
+  }
+
+  const tipsByMatch = groupBy(tipRows, (t) => t.matchId);
+  const roundPointsByRound = groupBy(roundPointRows, (r) => r.roundId);
+
+  const steps: VerlaufStep[] = [];
+  const gains: { stepIndex: number; userId: number; points: number }[] = [];
+  let playedSteps = 0;
+
+  for (const round of publishedRounds) {
+    for (const match of round.matches) {
+      const stepIndex = steps.length;
+      steps.push({ kind: "match", nr: match.nr });
+      // An unplayed match still gets its step, so the axis shows the whole
+      // season — it just carries no points and no line reaches it.
+      if (match.result !== null) playedSteps = stepIndex + 1;
+      for (const tip of tipsByMatch.get(match.id) ?? []) {
+        if (tip.points !== null) gains.push({ stepIndex, userId: tip.userId, points: tip.points });
+      }
+    }
+
+    // Only rounds that actually awarded bonus/malus get a column.
+    const awarded = roundPointsByRound.get(round.id);
+    if (awarded?.length) {
+      const stepIndex = steps.length;
+      steps.push({ kind: "roundPoints", roundNr: round.nr });
+      playedSteps = stepIndex + 1;
+      for (const entry of awarded) {
+        gains.push({ stepIndex, userId: entry.userId, points: entry.points });
+      }
+    }
+  }
+
+  if (includesExtraQuestions(championship.ruleset, championship)) {
+    const stepIndex = steps.length;
+    steps.push({ kind: "extraPoints" });
+    playedSteps = stepIndex + 1;
+    for (const answer of extraRows) {
+      if (answer.points !== null) {
+        gains.push({ stepIndex, userId: answer.userId, points: answer.points });
+      }
+    }
+  }
+
+  const series = calcProgression({ players, gains, playedSteps });
+  const byUser = new Map(series.map((s) => [s.userId, s]));
+
+  const merged = players.map((player) => {
+    const progression = byUser.get(player.userId);
+    return {
+      ...player,
+      positions: progression?.positions ?? [],
+      ranks: progression?.ranks ?? [],
+      points: progression?.points ?? [],
+    };
+  });
+
+  // Final row order — the right-edge labels sit at each line's last point, so
+  // emitting them in row order keeps them from overlapping.
+  merged.sort(
+    (a, b) =>
+      (a.positions.at(-1) ?? Number.MAX_SAFE_INTEGER) -
+        (b.positions.at(-1) ?? Number.MAX_SAFE_INTEGER) || a.name.localeCompare(b.name, "de"),
+  );
+
+  return { steps, playedSteps, players: merged };
+}
+
+function groupBy<T, K>(rows: T[], key: (row: T) => K): Map<K, T[]> {
+  const grouped = new Map<K, T[]>();
+  for (const row of rows) {
+    const list = grouped.get(key(row));
+    if (list) list.push(row);
+    else grouped.set(key(row), [row]);
+  }
+  return grouped;
+}

--- a/apps/web/app/lib/verlauf.server.ts
+++ b/apps/web/app/lib/verlauf.server.ts
@@ -18,9 +18,9 @@ import { db } from "./db.server.ts";
  * scores has a place and the chart ends on the Abschlusstabelle.
  */
 export type VerlaufStep =
-  | { kind: "match"; nr: number }
-  | { kind: "roundPoints"; roundNr: number }
-  | { kind: "extraPoints" };
+  | { kind: "match"; nr: number; endsRound: boolean }
+  | { kind: "roundPoints"; roundNr: number; endsRound: boolean }
+  | { kind: "extraPoints"; endsRound: false };
 
 export type VerlaufPlayer = {
   userId: number;
@@ -112,9 +112,11 @@ export async function getVerlauf(championshipId: number): Promise<Verlauf> {
   let playedSteps = 0;
 
   for (const round of publishedRounds) {
+    const roundStart = steps.length;
+
     for (const match of round.matches) {
       const stepIndex = steps.length;
-      steps.push({ kind: "match", nr: match.nr });
+      steps.push({ kind: "match", nr: match.nr, endsRound: false });
       // An unplayed match still gets its step, so the axis shows the whole
       // season — it just carries no points and no line reaches it.
       if (match.result !== null) playedSteps = stepIndex + 1;
@@ -127,17 +129,22 @@ export async function getVerlauf(championshipId: number): Promise<Verlauf> {
     const awarded = roundPointsByRound.get(round.id);
     if (awarded?.length) {
       const stepIndex = steps.length;
-      steps.push({ kind: "roundPoints", roundNr: round.nr });
+      steps.push({ kind: "roundPoints", roundNr: round.nr, endsRound: false });
       playedSteps = stepIndex + 1;
       for (const entry of awarded) {
         gains.push({ stepIndex, userId: entry.userId, points: entry.points });
       }
     }
+
+    // Mark whatever step the round ended on — its RP column if it has one,
+    // otherwise its last match. The chart draws a divider there.
+    const lastOfRound = steps.length > roundStart ? steps[steps.length - 1] : undefined;
+    if (lastOfRound && lastOfRound.kind !== "extraPoints") lastOfRound.endsRound = true;
   }
 
   if (includesExtraQuestions(championship.ruleset, championship)) {
     const stepIndex = steps.length;
-    steps.push({ kind: "extraPoints" });
+    steps.push({ kind: "extraPoints", endsRound: false });
     playedSteps = stepIndex + 1;
     for (const answer of extraRows) {
       if (answer.points !== null) {

--- a/apps/web/app/lib/verlauf.server.ts
+++ b/apps/web/app/lib/verlauf.server.ts
@@ -18,7 +18,7 @@ import { db } from "./db.server.ts";
  * scores has a place and the chart ends on the Abschlusstabelle.
  */
 export type VerlaufStep =
-  | { kind: "match"; nr: number; endsRound: boolean }
+  | { kind: "match"; nr: number; roundNr: number; endsRound: boolean }
   | { kind: "roundPoints"; roundNr: number; endsRound: boolean }
   | { kind: "extraPoints"; endsRound: false };
 
@@ -116,7 +116,7 @@ export async function getVerlauf(championshipId: number): Promise<Verlauf> {
 
     for (const match of round.matches) {
       const stepIndex = steps.length;
-      steps.push({ kind: "match", nr: match.nr, endsRound: false });
+      steps.push({ kind: "match", nr: match.nr, roundNr: round.nr, endsRound: false });
       // An unplayed match still gets its step, so the axis shows the whole
       // season — it just carries no points and no line reaches it.
       if (match.result !== null) playedSteps = stepIndex + 1;

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -30,6 +30,10 @@ const championshipViews = (id: string) => [
   route("tipps/:playerSlug?", "routes/public/championship/tipps/index.tsx", {
     id: `${id}-tipps`,
   }),
+  // :playerSlug only picks the highlighted line — see docs/verlauf-plan.md.
+  route("verlauf/:playerSlug?", "routes/public/championship/verlauf/index.tsx", {
+    id: `${id}-verlauf`,
+  }),
   route("zusatzfragen", "routes/public/championship/zusatzfragen/index.tsx", {
     id: `${id}-zusatzfragen`,
   }),

--- a/apps/web/app/routes/public/archiv/index.tsx
+++ b/apps/web/app/routes/public/archiv/index.tsx
@@ -1,4 +1,4 @@
-import { CellLink } from "#/components/cell-link.tsx";
+import { AppLink } from "#/components/app-link.tsx";
 import { getArchivChampionshipList, getEwigeTabelle } from "#/lib/archiv.server.ts";
 
 import type { Route } from "./+types/index";
@@ -40,7 +40,7 @@ export default function Archiv({ loaderData }: Route.ComponentProps) {
                 {championships.map((entry) => (
                   <tr key={entry.slug} className="border-subtle border-b last:border-b-0">
                     <td className="text-subtle py-2 pr-3 text-sm">
-                      <CellLink href={`/archiv/${entry.slug}`}>{entry.name}</CellLink>
+                      <AppLink href={`/archiv/${entry.slug}`}>{entry.name}</AppLink>
                     </td>
                     <td className="py-2 pr-3">
                       {entry.completed ? (

--- a/apps/web/app/routes/public/championship/_overview/current-matches.tsx
+++ b/apps/web/app/routes/public/championship/_overview/current-matches.tsx
@@ -1,4 +1,4 @@
-import { CellLink } from "#/components/cell-link.tsx";
+import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { SectionHeading } from "#/components/section-heading.tsx";
 import type { CurrentMatch } from "#/lib/spiele.server.ts";
@@ -28,10 +28,10 @@ export function ChampionshipCurrentMatches({
                   {match.date ? formatDate(match.date) : "–"}
                 </td>
                 <td className="py-2">
-                  <CellLink href={scoped(`/spiele/${match.nr}`)}>
+                  <AppLink href={scoped(`/spiele/${match.nr}`)}>
                     <span className="hidden lg:inline">{match.paarung}</span>
                     <span className="lg:hidden">{match.paarungShort}</span>
-                  </CellLink>
+                  </AppLink>
                 </td>
                 <td className="text-subtle w-px py-2 pl-3 text-right tabular-nums">
                   {match.result ?? "–:–"}

--- a/apps/web/app/routes/public/championship/_overview/standings.tsx
+++ b/apps/web/app/routes/public/championship/_overview/standings.tsx
@@ -1,4 +1,4 @@
-import { CellLink } from "#/components/cell-link.tsx";
+import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { SectionHeading } from "#/components/section-heading.tsx";
 import type { RankedPlayer } from "#/lib/ranking.server.ts";
@@ -35,7 +35,7 @@ export function ChampionshipStandings({
                   {sharesRankAbove ? "" : entry.rank}
                 </td>
                 <td className={`py-2 ${isUser ? "text-accent" : ""}`}>
-                  <CellLink href={scoped(`/tipps/${entry.slug}`)}>{entry.name}</CellLink>
+                  <AppLink href={scoped(`/tipps/${entry.slug}`)}>{entry.name}</AppLink>
                 </td>
                 <td className="py-2 text-right font-medium tabular-nums">{entry.total}</td>
               </tr>
@@ -56,9 +56,9 @@ export function ChampionshipStandings({
                 {userBelowTop3.rank}
               </td>
               <td className="text-accent py-2">
-                <CellLink href={scoped(`/tipps/${userBelowTop3.slug}`)}>
+                <AppLink href={scoped(`/tipps/${userBelowTop3.slug}`)}>
                   {userBelowTop3.name}
-                </CellLink>
+                </AppLink>
               </td>
               <td className="py-2 text-right font-medium tabular-nums">{userBelowTop3.total}</td>
             </tr>

--- a/apps/web/app/routes/public/championship/spiele/_round-item.tsx
+++ b/apps/web/app/routes/public/championship/spiele/_round-item.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { CellLink } from "#/components/cell-link.tsx";
+import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { RoundAccordion } from "#/components/round-accordion.tsx";
 import type { SpieleRound } from "#/lib/spiele.server.ts";
@@ -42,7 +42,7 @@ export function SpieleRoundItem({
           {round.matches.map((match) => (
             <tr key={match.id} className="border-subtle border-b last:border-b-0">
               <td className="text-subtle xs:px-2 w-px px-1 py-3 text-right tabular-nums">
-                <CellLink href={scoped(`/spiele/${match.nr}`)}>{match.nr}</CellLink>
+                <AppLink href={scoped(`/spiele/${match.nr}`)}>{match.nr}</AppLink>
               </td>
               <td className="xs:table-cell hidden w-px px-2 py-3 tabular-nums">
                 {match.date ? formatDate(match.date) : "–"}
@@ -51,10 +51,10 @@ export function SpieleRoundItem({
                 {match.liga ?? "–"}
               </td>
               <td className="xs:px-2 px-1 py-3">
-                <CellLink href={scoped(`/spiele/${match.nr}`)}>
+                <AppLink href={scoped(`/spiele/${match.nr}`)}>
                   <span className="hidden sm:inline">{match.paarung}</span>
                   <span className="sm:hidden">{match.paarungShort}</span>
-                </CellLink>
+                </AppLink>
               </td>
               <td className="xs:px-2 w-px px-1 py-3 text-center tabular-nums">
                 {match.result ?? "–:–"}

--- a/apps/web/app/routes/public/championship/spiele/detail.tsx
+++ b/apps/web/app/routes/public/championship/spiele/detail.tsx
@@ -3,8 +3,8 @@ import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router";
 
+import { AppLink } from "#/components/app-link.tsx";
 import { CellFlag } from "#/components/cell-flag.tsx";
-import { CellLink } from "#/components/cell-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { viewedChampionshipContext } from "#/lib/context.ts";
 import { getRanking } from "#/lib/ranking.server.ts";
@@ -207,7 +207,7 @@ export default function MatchDetail({ loaderData }: Route.ComponentProps) {
             {sortedRows.map((row) => (
               <tr key={row.userId} className="border-subtle border-b last:border-b-0">
                 <td className="xs:px-3 px-2 py-3 font-medium">
-                  <CellLink href={scoped(`/tipps/${row.slug}`)}>{row.name}</CellLink>
+                  <AppLink href={scoped(`/tipps/${row.slug}`)}>{row.name}</AppLink>
                 </td>
                 {match.tipsPublished && (
                   <td className="xs:px-6 relative w-px px-3 py-3 text-center tabular-nums">

--- a/apps/web/app/routes/public/championship/tabelle.tsx
+++ b/apps/web/app/routes/public/championship/tabelle.tsx
@@ -1,3 +1,6 @@
+import { Link } from "react-router";
+
+import { useScopedPath } from "#/components/championship-scope.tsx";
 import { RankingTable } from "#/components/ranking-table.tsx";
 import { viewedChampionshipContext, userContext } from "#/lib/context.ts";
 import { getRanking } from "#/lib/ranking.server.ts";
@@ -24,6 +27,7 @@ export async function loader({ context }: Route.LoaderArgs) {
 
 export default function Tabelle({ loaderData }: Route.ComponentProps) {
   const { championship, ranking, currentUserId } = loaderData;
+  const scoped = useScopedPath();
 
   if (!championship) {
     return (
@@ -39,9 +43,18 @@ export default function Tabelle({ loaderData }: Route.ComponentProps) {
       <title>{`Tabelle · ${championship.name} · runde.tips`}</title>
       <div className="mb-6 flex flex-col items-center gap-2">
         <h1 className="text-2xl font-semibold tracking-tight">{championship.name}</h1>
-        <p className="text-subtle text-sm">
-          {championship.completed ? "Abschlusstabelle" : "Aktuelle Tabelle"}
-        </p>
+        <div className="flex items-center gap-4 text-sm">
+          <span className="font-medium">
+            {championship.completed ? "Abschlusstabelle" : "Aktuelle Tabelle"}
+          </span>
+          <Link
+            to={scoped("/verlauf")}
+            prefetch="intent"
+            className="text-subtle hover:text-app focus-visible:ring-accent rounded-sm transition-colors outline-none focus-visible:ring-2"
+          >
+            Punkteverlauf
+          </Link>
+        </div>
       </div>
 
       {ranking.length === 0 ? (

--- a/apps/web/app/routes/public/championship/tabelle.tsx
+++ b/apps/web/app/routes/public/championship/tabelle.tsx
@@ -52,7 +52,7 @@ export default function Tabelle({ loaderData }: Route.ComponentProps) {
             prefetch="intent"
             className="text-subtle hover:text-app focus-visible:ring-accent rounded-sm transition-colors outline-none focus-visible:ring-2"
           >
-            Punkteverlauf
+            Verlauf
           </Link>
         </div>
       </div>

--- a/apps/web/app/routes/public/championship/tipps/_round-item.tsx
+++ b/apps/web/app/routes/public/championship/tipps/_round-item.tsx
@@ -1,8 +1,8 @@
 import { calcGoalDeviation } from "@tipprunde/domain/scoring";
 import { useMemo } from "react";
 
+import { AppLink } from "#/components/app-link.tsx";
 import { CellFlag } from "#/components/cell-flag.tsx";
-import { CellLink } from "#/components/cell-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { RoundAccordion } from "#/components/round-accordion.tsx";
 import type { PlayerRound } from "#/lib/spieler.server.ts";
@@ -70,20 +70,20 @@ export function PlayerRoundItem({
             return (
               <tr key={match.id} className="border-subtle border-b last:border-b-0">
                 <td className="text-subtle xs:px-2 w-px px-1 py-3 text-right tabular-nums">
-                  <CellLink href={scoped(`/spiele/${match.nr}`)}>{match.nr}</CellLink>
+                  <AppLink href={scoped(`/spiele/${match.nr}`)}>{match.nr}</AppLink>
                 </td>
                 <td className="hidden w-px px-2 py-3 tabular-nums md:table-cell">
                   {match.date ? formatDate(match.date) : "–"}
                 </td>
                 <td className="xs:px-2 px-1 py-3">
-                  <CellLink href={scoped(`/spiele/${match.nr}`)}>
+                  <AppLink href={scoped(`/spiele/${match.nr}`)}>
                     <span className="hidden sm:inline">
                       {match.hometeam?.name ?? "–"} – {match.awayteam?.name ?? "–"}
                     </span>
                     <span className="sm:hidden">
                       {match.hometeam?.shortName ?? "–"} – {match.awayteam?.shortName ?? "–"}
                     </span>
-                  </CellLink>
+                  </AppLink>
                 </td>
                 <td className="xs:px-2 w-px px-1 py-3 text-center tabular-nums">
                   {match.result ?? "–:–"}

--- a/apps/web/app/routes/public/championship/tipps/index.tsx
+++ b/apps/web/app/routes/public/championship/tipps/index.tsx
@@ -1,10 +1,10 @@
+import { PlayerSwitch } from "#/components/player-switch.tsx";
 import { getRuleset } from "#/lib/championship.server.ts";
 import { viewedChampionshipContext, userContext } from "#/lib/context.ts";
 import { getRanking, type RankedPlayer, resolvePlayer } from "#/lib/ranking.server.ts";
 import { findUserBySlug, getPlayerMatches, type PlayerRound } from "#/lib/spieler.server.ts";
 
 import type { Route } from "./+types/index";
-import { PlayerSwitch } from "./_player-switch.tsx";
 import { PlayerRoundItem } from "./_round-item.tsx";
 
 export async function loader({ context, params }: Route.LoaderArgs) {
@@ -103,7 +103,7 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
       <div className="xs:px-0 mb-6 flex flex-col items-center gap-2 px-4">
         <div className="flex items-center gap-1.5">
           <h1 className="text-2xl font-semibold tracking-tight">{player.name}</h1>
-          <PlayerSwitch players={players} currentSlug={player.slug} />
+          <PlayerSwitch players={players} currentSlug={player.slug} basePath="/tipps" />
         </div>
         <p className="text-subtle text-center text-sm leading-relaxed">
           {championshipName} · Platz {player.rank}

--- a/apps/web/app/routes/public/championship/tipps/index.tsx
+++ b/apps/web/app/routes/public/championship/tipps/index.tsx
@@ -1,4 +1,4 @@
-import { ChartLineIcon } from "lucide-react";
+import { TrendingUpIcon } from "lucide-react";
 
 import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
@@ -117,7 +117,7 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
               slug rides along, so the chart opens with this player highlighted. */}
           <AppLink href={scoped(`/verlauf/${player.slug}`)}>
             <span className="inline-flex items-baseline gap-1">
-              <ChartLineIcon className="relative top-[0.1em] size-3.5 shrink-0" />
+              <TrendingUpIcon className="relative top-[0.1em] size-3.5 shrink-0" />
               Platz {player.rank}
             </span>
           </AppLink>

--- a/apps/web/app/routes/public/championship/tipps/index.tsx
+++ b/apps/web/app/routes/public/championship/tipps/index.tsx
@@ -1,3 +1,5 @@
+import { ChartLineIcon } from "lucide-react";
+
 import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { PlayerSwitch } from "#/components/player-switch.tsx";
@@ -113,7 +115,12 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
           {/* The Verlauf is the history of exactly this number, so the question
               "how did I end up ninth?" gets its answer where it is asked. The
               slug rides along, so the chart opens with this player highlighted. */}
-          <AppLink href={scoped(`/verlauf/${player.slug}`)}>Platz {player.rank}</AppLink>
+          <AppLink href={scoped(`/verlauf/${player.slug}`)}>
+            <span className="inline-flex items-baseline gap-1">
+              <ChartLineIcon className="relative top-[0.1em] size-3.5 shrink-0" />
+              Platz {player.rank}
+            </span>
+          </AppLink>
           <br className="xs:hidden" />
           <span className="xs:inline hidden"> · </span>
           {player.tipPoints} Tippunkte · {playerSpiele} Spiele

--- a/apps/web/app/routes/public/championship/tipps/index.tsx
+++ b/apps/web/app/routes/public/championship/tipps/index.tsx
@@ -1,3 +1,5 @@
+import { AppLink } from "#/components/app-link.tsx";
+import { useScopedPath } from "#/components/championship-scope.tsx";
 import { PlayerSwitch } from "#/components/player-switch.tsx";
 import { getRuleset } from "#/lib/championship.server.ts";
 import { viewedChampionshipContext, userContext } from "#/lib/context.ts";
@@ -50,6 +52,7 @@ export async function loader({ context, params }: Route.LoaderArgs) {
 }
 
 export default function Tipps({ loaderData }: Route.ComponentProps) {
+  const scoped = useScopedPath();
   const {
     championshipName,
     player,
@@ -106,7 +109,11 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
           <PlayerSwitch players={players} currentSlug={player.slug} basePath="/tipps" />
         </div>
         <p className="text-subtle text-center text-sm leading-relaxed">
-          {championshipName} · Platz {player.rank}
+          {championshipName} ·{" "}
+          {/* The Verlauf is the history of exactly this number, so the question
+              "how did I end up ninth?" gets its answer where it is asked. The
+              slug rides along, so the chart opens with this player highlighted. */}
+          <AppLink href={scoped(`/verlauf/${player.slug}`)}>Platz {player.rank}</AppLink>
           <br className="xs:hidden" />
           <span className="xs:inline hidden"> · </span>
           {player.tipPoints} Tippunkte · {playerSpiele} Spiele

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -272,12 +272,15 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
             />
           ))}
 
-          {/* Rule line wherever points arrive outside a match, so an RP or ZP
-              column is still marked even when its label lost the space. */}
+          {/* Divider at each round's end — its RP column where there is one,
+              otherwise its last match. Never on the final step: a line with
+              nothing after it just boxes the chart in. That also keeps the ZP
+              column open on the right while still being fenced off on the
+              left by the preceding round's divider. */}
           {steps.map((step, i) =>
-            step.kind === "match" ? null : (
+            step.endsRound && i < steps.length - 1 ? (
               <line
-                key={`rule-${i}`}
+                key={`divider-${i}`}
                 x1={x(i)}
                 x2={x(i)}
                 y1={0}
@@ -286,7 +289,7 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
                 strokeWidth={1}
                 className="text-subtle opacity-25"
               />
-            ),
+            ) : null,
           )}
 
           {/* One keyed line per player, ordered context → leader → focus so

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 
 import { useScopedPath } from "#/components/championship-scope.tsx";
+import { PlayerSwitch } from "#/components/player-switch.tsx";
 import type { VerlaufPlayer, VerlaufStep } from "#/lib/verlauf.server.ts";
 
 const ROW_HEIGHT = 22;
@@ -225,40 +226,53 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
 
   return (
     <div ref={ref} className="relative w-full">
-      {/* Fixed place, not a floating tooltip. A tooltip that dodges the focused
-          line has no position the eye can learn, and on a landscape phone the
-          chart is taller than the viewport — half the time it landed below the
-          fold. min-h reserves the second line so the chart does not shift when
-          the text wraps. */}
-      <p
-        aria-live="polite"
-        // Sticky under the h-14 header: on a landscape phone the chart is
-        // taller than the viewport, so a readout fixed to the top of the chart
-        // scrolls away exactly when you are reading the lower ranks.
-        className="text-subtle bg-surface xs:min-h-5 sticky top-14 z-10 mb-1.5 min-h-10 py-1 text-center text-xs leading-5"
-      >
-        {shownStepDef && <span className="text-muted">{stepTitle(shownStepDef)}</span>}
-        {readout.focus && (
-          <>
-            {/* No name here on purpose: the row above already names the
+      {/* Fixed place, not a floating tooltip: one that dodges the focused line
+          has no position the eye can learn, and on a landscape phone the chart
+          is taller than the viewport, so half the time it landed below the
+          fold. Sticky under the h-14 header, and the focused player travels
+          with it — otherwise scrolling into the lower ranks leaves the numbers
+          below with nothing naming who they belong to. */}
+      <div className="bg-surface sticky top-14 z-10 pb-1.5">
+        {focus && (
+          <div className="flex items-center justify-center gap-1.5 py-1 text-sm">
+            <span className="text-subtle">Hervorgehoben:</span>
+            <span className="text-accent font-medium">{focus.name}</span>
+            <PlayerSwitch
+              players={players}
+              currentSlug={focus.slug}
+              basePath="/verlauf"
+              label="Hervorgehobenen Spieler wechseln"
+            />
+          </div>
+        )}
+        {/* min-h reserves the wrapped line so the chart does not shift. */}
+        <p
+          aria-live="polite"
+          className="text-subtle xs:min-h-5 min-h-10 text-center text-xs leading-5"
+        >
+          {shownStepDef && <span className="text-muted">{stepTitle(shownStepDef)}</span>}
+          {readout.focus && (
+            <>
+              {/* No name here on purpose: the row above already names the
                 highlighted player in accent, and so does their line's label.
                 A third one made the colour stop meaning anything. */}
-            {" · Rang "}
-            {readout.focus.rank}
-            {" · "}
-            <span className="tabular-nums">{readout.focus.points}</span> P
-            {readout.focus.tiedWith.length > 0 && (
-              <> · punktgleich mit {formatTiedWith(readout.focus.tiedWith)}</>
-            )}
-            {readout.leader && gap > 0 && (
-              <>
-                {" · Rückstand auf "}
-                {readout.leader.name}: <span className="tabular-nums">{gap}</span> P
-              </>
-            )}
-          </>
-        )}
-      </p>
+              {" · Rang "}
+              {readout.focus.rank}
+              {" · "}
+              <span className="tabular-nums">{readout.focus.points}</span> P
+              {readout.focus.tiedWith.length > 0 && (
+                <> · punktgleich mit {formatTiedWith(readout.focus.tiedWith)}</>
+              )}
+              {readout.leader && gap > 0 && (
+                <>
+                  {" · Rückstand auf "}
+                  {readout.leader.name}: <span className="tabular-nums">{gap}</span> P
+                </>
+              )}
+            </>
+          )}
+        </p>
+      </div>
 
       <svg
         width={width}

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -487,29 +487,35 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
       {/* The lines carry no text, so the focused player's run is spelled out
           for screen readers. Only theirs: one table per player would be ~60
           rows times 18, which helps nobody. */}
+      {/* sr-only has to sit on a div, not on the table: `height: 1px` is only a
+          minimum for a table box, so the table keeps its full ~1500px and,
+          being absolutely positioned, drags the page's scroll height along
+          with it. A div honours the height and clips the table inside. */}
       {focus && (
-        <table className="sr-only">
-          <caption>Rangverlauf von {focus.name}</caption>
-          <thead>
-            <tr>
-              <th scope="col">Schritt</th>
-              <th scope="col">Rang</th>
-              <th scope="col">Punkte</th>
-            </tr>
-          </thead>
-          <tbody>
-            {focus.ranks.map((rank, i) => {
-              const step = steps[i];
-              return (
-                <tr key={i}>
-                  <th scope="row">{step ? stepTitle(step) : `Schritt ${i + 1}`}</th>
-                  <td>{rank}</td>
-                  <td>{focus.points[i]}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="sr-only">
+          <table>
+            <caption>Rangverlauf von {focus.name}</caption>
+            <thead>
+              <tr>
+                <th scope="col">Schritt</th>
+                <th scope="col">Rang</th>
+                <th scope="col">Punkte</th>
+              </tr>
+            </thead>
+            <tbody>
+              {focus.ranks.map((rank, i) => {
+                const step = steps[i];
+                return (
+                  <tr key={i}>
+                    <th scope="row">{step ? stepTitle(step) : `Schritt ${i + 1}`}</th>
+                    <td>{rank}</td>
+                    <td>{focus.points[i]}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -211,7 +211,7 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
         onBlur={() => setActiveStep(null)}
         className="focus-visible:outline-accent rounded-sm outline-none focus-visible:outline-2"
         aria-label={
-          `Punkteverlauf: Rangentwicklung von ${players.length} Spielern über ` +
+          `Verlauf: Rangentwicklung von ${players.length} Spielern über ` +
           `${playedSteps} gewertete Schritte.` +
           (focus ? ` Hervorgehoben: ${focus.name}.` : "")
         }

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -7,8 +7,16 @@ import type { VerlaufPlayer, VerlaufStep } from "#/lib/verlauf.server.ts";
 
 const ROW_HEIGHT = 22;
 const MARGIN = { top: 10, right: 8, bottom: 24, left: 8 };
-/** Reserved for the right-edge name labels — only claimed when they show. */
-const LABEL_WIDTH = 92;
+/** Gap between a line's end and its name. */
+const LABEL_GAP = 8;
+/** Ceiling for the name column, so one long name cannot eat the plot. */
+const LABEL_MAX = 120;
+/**
+ * Rough width of one character at the label's 11px — only seeds the
+ * reservation, since the server cannot measure text. The real width is
+ * measured on mount and corrects this.
+ */
+const LABEL_CHAR_WIDTH = 6.4;
 /** Below this the labels cost more width than they are worth (see plan). */
 const LABEL_BREAKPOINT = 640;
 /** Server render has no measurement; the client re-lays-out on first frame. */
@@ -123,12 +131,19 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
   const { ref, width } = useMeasuredWidth();
   const scoped = useScopedPath();
   const [activeStep, setActiveStep] = useState<number | null>(null);
+  const labelsRef = useRef<SVGGElement>(null);
+  const [measuredLabelWidth, setMeasuredLabelWidth] = useState<number | null>(null);
 
   const showLabels = width >= LABEL_BREAKPOINT;
-  const plotWidth = Math.max(
-    0,
-    width - MARGIN.left - MARGIN.right - (showLabels ? LABEL_WIDTH : 0),
-  );
+  // The name column takes only what the longest name needs. Estimated from
+  // character count for the first paint (the server cannot measure text), then
+  // corrected by a real measurement below — in landscape especially, a fixed
+  // reservation hands the plot's width to whitespace.
+  const longestName = players.reduce((max, p) => Math.max(max, p.name.length), 0);
+  const estimatedLabelWidth = Math.min(LABEL_MAX, longestName * LABEL_CHAR_WIDTH + LABEL_GAP);
+  const labelWidth = showLabels ? (measuredLabelWidth ?? estimatedLabelWidth) : 0;
+
+  const plotWidth = Math.max(0, width - MARGIN.left - MARGIN.right - labelWidth);
   const plotHeight = players.length * ROW_HEIGHT;
   const height = plotHeight + MARGIN.top + MARGIN.bottom;
 
@@ -139,7 +154,7 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
   const leader = players[0];
   const focus = players.find((p) => p.slug === focusSlug);
   /** Labels hang off the last played step, not the plot edge — see below. */
-  const labelX = x(Math.max(0, playedSteps - 1)) + 6;
+  const labelX = x(Math.max(0, playedSteps - 1)) + LABEL_GAP;
   /** SVG has no z-index; paint order is document order. */
   const paintOrder = players.toSorted(
     (a, b) => (a === focus ? 2 : a === leader ? 1 : 0) - (b === focus ? 2 : b === leader ? 1 : 0),
@@ -177,6 +192,29 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
 
   const active = activeStep === null ? null : buildReadout(players, activeStep, focusSlug);
 
+  // Measure the rendered names once they exist, so the reservation matches the
+  // font rather than the estimate. Widths do not depend on where the labels
+  // sit, so this settles after one correction.
+  const nameKey = players.map((p) => p.name).join("|");
+  useEffect(() => {
+    if (!showLabels || !labelsRef.current) {
+      setMeasuredLabelWidth(null);
+      return;
+    }
+    let widest = 0;
+    for (const node of labelsRef.current.querySelectorAll("text")) {
+      widest = Math.max(widest, node.getBBox().width);
+    }
+    if (widest === 0) return;
+    const next = Math.min(LABEL_MAX, Math.ceil(widest) + LABEL_GAP);
+    setMeasuredLabelWidth((previous) =>
+      previous === null || Math.abs(previous - next) > 1 ? next : previous,
+    );
+    // `width` is in here on purpose: at mount the text may not be laid out yet
+    // and getBBox reports 0, and without a re-run the estimate would stand for
+    // good. The measured width settles the values, so this cannot loop.
+  }, [showLabels, nameKey, width]);
+
   return (
     <div ref={ref} className="relative w-full">
       <svg
@@ -209,7 +247,10 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
           event.preventDefault();
         }}
         onBlur={() => setActiveStep(null)}
-        className="focus-visible:outline-accent rounded-sm outline-none focus-visible:outline-2"
+        // max-w-full is the safety net: the width is only known after mount, so
+        // the very first paint uses a default that may exceed the container.
+        // Clipping one frame is fine; a horizontally scrolling page is not.
+        className="focus-visible:outline-accent max-w-full rounded-sm outline-none focus-visible:outline-2"
         aria-label={
           `Verlauf: Rangentwicklung von ${players.length} Spielern über ` +
           `${playedSteps} gewertete Schritte.` +
@@ -340,44 +381,46 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
               Anchored to where the lines actually stop, not to the plot edge:
               in a running championship the axis reaches into unplayed steps,
               and labels parked out there would name nothing. */}
-          {showLabels &&
-            players.map((player) => {
-              const row = player.positions.at(-1);
-              if (row === undefined) return null;
-              return (
-                <Link
-                  key={player.userId}
-                  to={scoped(`/verlauf/${player.slug}`)}
-                  preventScrollReset
-                  aria-label={`${player.name} hervorheben`}
-                  className="focus-visible:outline-accent outline-none focus-visible:outline-2"
-                >
-                  {/* The glyphs alone are a poor target, especially on touch. */}
-                  <rect
-                    x={labelX - 3}
-                    y={y(row) - ROW_HEIGHT / 2}
-                    width={LABEL_WIDTH}
-                    height={ROW_HEIGHT}
-                    fill="transparent"
-                  />
-                  <text
-                    x={labelX}
-                    y={y(row)}
-                    dominantBaseline="middle"
-                    className={cx(
-                      "fill-current text-[11px] transition-[opacity,color] duration-150 ease-out",
-                      player === focus
-                        ? "text-accent font-medium"
-                        : player === leader
-                          ? "text-app"
-                          : "text-subtle opacity-70 hover:opacity-100",
-                    )}
+          <g ref={labelsRef}>
+            {showLabels &&
+              players.map((player) => {
+                const row = player.positions.at(-1);
+                if (row === undefined) return null;
+                return (
+                  <Link
+                    key={player.userId}
+                    to={scoped(`/verlauf/${player.slug}`)}
+                    preventScrollReset
+                    aria-label={`${player.name} hervorheben`}
+                    className="focus-visible:outline-accent outline-none focus-visible:outline-2"
                   >
-                    {player.name}
-                  </text>
-                </Link>
-              );
-            })}
+                    {/* The glyphs alone are a poor target, especially on touch. */}
+                    <rect
+                      x={labelX - 3}
+                      y={y(row) - ROW_HEIGHT / 2}
+                      width={labelWidth}
+                      height={ROW_HEIGHT}
+                      fill="transparent"
+                    />
+                    <text
+                      x={labelX}
+                      y={y(row)}
+                      dominantBaseline="middle"
+                      className={cx(
+                        "fill-current text-[11px] transition-[opacity,color] duration-150 ease-out",
+                        player === focus
+                          ? "text-accent font-medium"
+                          : player === leader
+                            ? "text-app"
+                            : "text-subtle opacity-70 hover:opacity-100",
+                      )}
+                    >
+                      {player.name}
+                    </text>
+                  </Link>
+                );
+              })}
+          </g>
         </g>
       </svg>
 

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -140,6 +140,10 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
   const focus = players.find((p) => p.slug === focusSlug);
   /** Labels hang off the last played step, not the plot edge — see below. */
   const labelX = x(Math.max(0, playedSteps - 1)) + 6;
+  /** SVG has no z-index; paint order is document order. */
+  const paintOrder = players.toSorted(
+    (a, b) => (a === focus ? 2 : a === leader ? 1 : 0) - (b === focus ? 2 : b === leader ? 1 : 0),
+  );
 
   // Pick x labels that do not collide. Special steps go first so they win the
   // space, and they are walked right-to-left so a final ZP beats an RP sitting
@@ -244,47 +248,33 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
             ),
           )}
 
-          {/* Context layer: everyone who is neither focused nor leading. */}
-          {players.map((player) =>
-            player === focus || player === leader ? null : (
+          {/* One keyed line per player, ordered context → leader → focus so
+              SVG paint order puts the important ones on top. Deliberately a
+              single list: rendering the layers as separate blocks would remount
+              a line whenever the focus moves, and a remounted element cannot
+              transition — switching players would snap instead of fading. */}
+          {paintOrder.map((player) => {
+            const isFocus = player === focus;
+            const isLeader = !isFocus && player === leader;
+            return (
               <polyline
                 key={player.userId}
                 points={line(player)}
                 fill="none"
                 stroke="currentColor"
-                strokeWidth={1.5}
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="text-subtle opacity-30"
+                className={cx(
+                  "transition-[stroke-width,opacity,color] duration-200 ease-out",
+                  isFocus
+                    ? "text-accent [stroke-width:2.5]"
+                    : isLeader
+                      ? "text-app opacity-70 [stroke-width:2]"
+                      : "text-subtle opacity-30 [stroke-width:1.5]",
+                )}
               />
-            ),
-          )}
-
-          {/* Reference layer: the leader, unless they are already the focus. */}
-          {leader && leader !== focus && (
-            <polyline
-              points={line(leader)}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-app opacity-70"
-            />
-          )}
-
-          {/* Focus layer, drawn last so it wins every crossing. */}
-          {focus && (
-            <polyline
-              points={line(focus)}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-accent"
-            />
-          )}
+            );
+          })}
 
           {/* Hit area for the crosshair. Pointer moves only track a mouse —
               on touch a tap sets the step and it stays put, so dragging over
@@ -375,7 +365,7 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
                     y={y(row)}
                     dominantBaseline="middle"
                     className={cx(
-                      "fill-current text-[11px]",
+                      "fill-current text-[11px] transition-[opacity,color] duration-150 ease-out",
                       player === focus
                         ? "text-accent font-medium"
                         : player === leader

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -48,11 +48,15 @@ function stepLabel(step: VerlaufStep): string {
 function stepTitle(step: VerlaufStep): string {
   switch (step.kind) {
     case "match":
-      return `Nach Spiel ${step.nr}`;
+      // Naming the round only where one closes keeps it informative instead of
+      // repeating the same parenthetical down every match of the round.
+      return step.endsRound
+        ? `Nach Spiel ${step.nr} (Runde ${step.roundNr})`
+        : `Nach Spiel ${step.nr}`;
     case "roundPoints":
       return `Rundenpunkte Runde ${step.roundNr}`;
     case "extraPoints":
-      return "Nach Zusatzpunkten";
+      return "Mit Zusatzpunkten";
   }
 }
 
@@ -486,7 +490,9 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
                   punktgleich mit {formatTiedWith(active.focus.tiedWith)}
                 </p>
               )}
-              {active.leader && active.leader.name !== active.focus.name && (
+              {/* A gap of zero means the leader is already named in the
+                  punktgleich line above — saying it twice adds nothing. */}
+              {active.leader && active.leader.points > active.focus.points && (
                 <p className="text-subtle mt-0.5">
                   Rückstand auf {active.leader.name}:{" "}
                   <span className="tabular-nums">{active.leader.points - active.focus.points}</span>{" "}

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -23,8 +23,6 @@ const LABEL_BREAKPOINT = 640;
 const DEFAULT_WIDTH = 900;
 /** Minimum horizontal room per x-axis label before we start skipping some. */
 const LABEL_PITCH = 30;
-/** Half the tooltip's fixed width — it is centred, so this is its clamp. */
-const TOOLTIP_HALF = 104;
 
 interface Props {
   steps: VerlaufStep[];
@@ -194,7 +192,13 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
     return Math.min(lastStep, Math.max(0, Math.round(ratio * (steps.length - 1))));
   };
 
-  const active = activeStep === null ? null : buildReadout(players, activeStep, focusSlug);
+  // The readout always shows a step — the crosshair's while scrubbing, the
+  // final one at rest — so its line never empties out and shoves the chart
+  // around as you move across it.
+  const shownStep = activeStep ?? lastStep;
+  const readout = buildReadout(players, shownStep, focusSlug);
+  const shownStepDef = steps[shownStep];
+  const gap = readout.leader && readout.focus ? readout.leader.points - readout.focus.points : 0;
 
   // Measure the rendered names once they exist, so the reservation matches the
   // font rather than the estimate. Widths do not depend on where the labels
@@ -221,6 +225,40 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
 
   return (
     <div ref={ref} className="relative w-full">
+      {/* Fixed place, not a floating tooltip. A tooltip that dodges the focused
+          line has no position the eye can learn, and on a landscape phone the
+          chart is taller than the viewport — half the time it landed below the
+          fold. min-h reserves the second line so the chart does not shift when
+          the text wraps. */}
+      <p
+        aria-live="polite"
+        // Sticky under the h-14 header: on a landscape phone the chart is
+        // taller than the viewport, so a readout fixed to the top of the chart
+        // scrolls away exactly when you are reading the lower ranks.
+        className="text-subtle bg-surface xs:min-h-5 sticky top-14 z-10 mb-1.5 min-h-10 py-1 text-center text-xs leading-5"
+      >
+        {shownStepDef && <span className="text-muted">{stepTitle(shownStepDef)}</span>}
+        {readout.focus && (
+          <>
+            {" · "}
+            <span className="text-accent font-medium">{readout.focus.name}</span>
+            {" · Rang "}
+            {readout.focus.rank}
+            {" · "}
+            <span className="tabular-nums">{readout.focus.points}</span> P
+            {readout.focus.tiedWith.length > 0 && (
+              <> · punktgleich mit {formatTiedWith(readout.focus.tiedWith)}</>
+            )}
+            {readout.leader && gap > 0 && (
+              <>
+                {" · Rückstand auf "}
+                {readout.leader.name}: <span className="tabular-nums">{gap}</span> P
+              </>
+            )}
+          </>
+        )}
+      </p>
+
       <svg
         width={width}
         height={height}
@@ -457,60 +495,6 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
             })}
           </tbody>
         </table>
-      )}
-
-      {activeStep !== null && active && (
-        <div
-          role="status"
-          className="border-subtle bg-surface-raised shadow-popover text-app pointer-events-none absolute z-10 w-[13rem] -translate-x-1/2 rounded-md border px-3 py-2 text-xs"
-          style={{
-            left: Math.min(
-              Math.max(MARGIN.left + x(activeStep), TOOLTIP_HALF),
-              Math.max(TOOLTIP_HALF, width - TOOLTIP_HALF),
-            ),
-            // Sit in whichever half the focused line is not in, so the tooltip
-            // never covers the very point being read.
-            top:
-              (focus?.positions[activeStep] ?? 0) < players.length / 2
-                ? MARGIN.top + plotHeight * 0.55
-                : MARGIN.top,
-          }}
-        >
-          <p className="text-muted mb-1 font-medium">{stepTitle(steps[activeStep]!)}</p>
-          {active.focus ? (
-            <>
-              <p>
-                <span className="text-accent font-medium">{active.focus.name}</span>
-                <span className="text-subtle"> · Rang {active.focus.rank} · </span>
-                <span className="tabular-nums">{active.focus.points}</span>
-                <span className="text-subtle"> P</span>
-              </p>
-              {active.focus.tiedWith.length > 0 && (
-                <p className="text-subtle mt-0.5">
-                  punktgleich mit {formatTiedWith(active.focus.tiedWith)}
-                </p>
-              )}
-              {/* A gap of zero means the leader is already named in the
-                  punktgleich line above — saying it twice adds nothing. */}
-              {active.leader && active.leader.points > active.focus.points && (
-                <p className="text-subtle mt-0.5">
-                  Rückstand auf {active.leader.name}:{" "}
-                  <span className="tabular-nums">{active.leader.points - active.focus.points}</span>{" "}
-                  P
-                </p>
-              )}
-            </>
-          ) : (
-            active.leader && (
-              <p>
-                <span className="font-medium">{active.leader.name}</span>
-                <span className="text-subtle"> führt mit </span>
-                <span className="tabular-nums">{active.leader.points}</span>
-                <span className="text-subtle"> P</span>
-              </p>
-            )
-          )}
-        </div>
       )}
     </div>
   );

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -240,8 +240,9 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
         {shownStepDef && <span className="text-muted">{stepTitle(shownStepDef)}</span>}
         {readout.focus && (
           <>
-            {" · "}
-            <span className="text-accent font-medium">{readout.focus.name}</span>
+            {/* No name here on purpose: the row above already names the
+                highlighted player in accent, and so does their line's label.
+                A third one made the colour stop meaning anything. */}
             {" · Rang "}
             {readout.focus.rank}
             {" · "}

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -1,0 +1,237 @@
+import { cx } from "@tipprunde/ui";
+import { useEffect, useRef, useState } from "react";
+
+import type { VerlaufPlayer, VerlaufStep } from "#/lib/verlauf.server.ts";
+
+const ROW_HEIGHT = 22;
+const MARGIN = { top: 10, right: 8, bottom: 24, left: 8 };
+/** Reserved for the right-edge name labels — only claimed when they show. */
+const LABEL_WIDTH = 92;
+/** Below this the labels cost more width than they are worth (see plan). */
+const LABEL_BREAKPOINT = 640;
+/** Server render has no measurement; the client re-lays-out on first frame. */
+const DEFAULT_WIDTH = 900;
+/** Minimum horizontal room per x-axis label before we start skipping some. */
+const LABEL_PITCH = 30;
+
+interface Props {
+  steps: VerlaufStep[];
+  playedSteps: number;
+  /** Ordered by final row — players[0] is the leader. */
+  players: VerlaufPlayer[];
+  focusSlug: string | undefined;
+}
+
+function stepLabel(step: VerlaufStep): string {
+  switch (step.kind) {
+    case "match":
+      return String(step.nr);
+    case "roundPoints":
+      return "RP";
+    case "extraPoints":
+      return "ZP";
+  }
+}
+
+/** Width of the element, measured on the client; SSR falls back to a default. */
+function useMeasuredWidth() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const measured = entry?.contentRect.width ?? 0;
+      if (measured > 0) setWidth(measured);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, width };
+}
+
+/**
+ * Rank progression as a bump chart: one row per player, ordered best-first,
+ * every player on their own row at every step.
+ *
+ * Rows are display rows, not ranks — tied players share a rank but never a
+ * row, or their lines would coincide. `calcProgression` assigns them; see
+ * docs/verlauf-plan.md.
+ */
+export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
+  const { ref, width } = useMeasuredWidth();
+
+  const showLabels = width >= LABEL_BREAKPOINT;
+  const plotWidth = Math.max(
+    0,
+    width - MARGIN.left - MARGIN.right - (showLabels ? LABEL_WIDTH : 0),
+  );
+  const plotHeight = players.length * ROW_HEIGHT;
+  const height = plotHeight + MARGIN.top + MARGIN.bottom;
+
+  const x = (stepIndex: number) =>
+    steps.length > 1 ? (stepIndex / (steps.length - 1)) * plotWidth : plotWidth / 2;
+  const y = (row: number) => row * ROW_HEIGHT + ROW_HEIGHT / 2;
+
+  const leader = players[0];
+  const focus = players.find((p) => p.slug === focusSlug);
+
+  // Pick x labels that do not collide. Special steps go first so they win the
+  // space, and they are walked right-to-left so a final ZP beats an RP sitting
+  // right next to it — a dropped RP label still has its rule line below.
+  const labelled = new Set<number>();
+  const takenX: number[] = [];
+  const fits = (stepIndex: number) =>
+    takenX.every((taken) => Math.abs(taken - x(stepIndex)) >= LABEL_PITCH);
+  const take = (stepIndex: number) => {
+    labelled.add(stepIndex);
+    takenX.push(x(stepIndex));
+  };
+  for (let i = steps.length - 1; i >= 0; i--) {
+    if (steps[i]?.kind !== "match" && fits(i)) take(i);
+  }
+  for (let i = 0; i < steps.length; i++) {
+    if (steps[i]?.kind === "match" && fits(i)) take(i);
+  }
+
+  const line = (player: VerlaufPlayer) =>
+    player.positions.map((row, i) => `${x(i)},${y(row)}`).join(" ");
+
+  return (
+    <div ref={ref} className="w-full">
+      <svg
+        width={width}
+        height={height}
+        role="img"
+        aria-label={
+          `Punkteverlauf: Rangentwicklung von ${players.length} Spielern über ` +
+          `${playedSteps} gewertete Schritte.` +
+          (focus ? ` Hervorgehoben: ${focus.name}.` : "")
+        }
+      >
+        <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+          {/* Row guides — one per rank position, recessive. */}
+          {players.map((_, row) => (
+            <line
+              key={row}
+              x1={0}
+              x2={plotWidth}
+              y1={y(row)}
+              y2={y(row)}
+              stroke="currentColor"
+              strokeWidth={1}
+              className="text-subtle opacity-10"
+            />
+          ))}
+
+          {/* Rule line wherever points arrive outside a match, so an RP or ZP
+              column is still marked even when its label lost the space. */}
+          {steps.map((step, i) =>
+            step.kind === "match" ? null : (
+              <line
+                key={`rule-${i}`}
+                x1={x(i)}
+                x2={x(i)}
+                y1={0}
+                y2={plotHeight}
+                stroke="currentColor"
+                strokeWidth={1}
+                className="text-subtle opacity-25"
+              />
+            ),
+          )}
+
+          {/* Context layer: everyone who is neither focused nor leading. */}
+          {players.map((player) =>
+            player === focus || player === leader ? null : (
+              <polyline
+                key={player.userId}
+                points={line(player)}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-subtle opacity-30"
+              />
+            ),
+          )}
+
+          {/* Reference layer: the leader, unless they are already the focus. */}
+          {leader && leader !== focus && (
+            <polyline
+              points={line(leader)}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-app opacity-70"
+            />
+          )}
+
+          {/* Focus layer, drawn last so it wins every crossing. */}
+          {focus && (
+            <polyline
+              points={line(focus)}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-accent"
+            />
+          )}
+
+          {/* x axis */}
+          {steps.map((step, i) =>
+            labelled.has(i) ? (
+              <text
+                key={i}
+                x={x(i)}
+                y={plotHeight + 16}
+                textAnchor="middle"
+                className={cx(
+                  "fill-current text-[10px] tabular-nums",
+                  step.kind === "match" ? "text-muted opacity-60" : "text-app opacity-80",
+                )}
+              >
+                {stepLabel(step)}
+              </text>
+            ) : null,
+          )}
+
+          {/* Direct labels at each line's end — the legend, on wide screens.
+              Anchored to where the lines actually stop, not to the plot edge:
+              in a running championship the axis reaches into unplayed steps,
+              and labels parked out there would name nothing. */}
+          {showLabels &&
+            players.map((player) => {
+              const row = player.positions.at(-1);
+              if (row === undefined) return null;
+              return (
+                <text
+                  key={player.userId}
+                  x={x(Math.max(0, playedSteps - 1)) + 6}
+                  y={y(row)}
+                  dominantBaseline="middle"
+                  className={cx(
+                    "fill-current text-[11px]",
+                    player === focus
+                      ? "text-accent font-medium"
+                      : player === leader
+                        ? "text-app"
+                        : "text-subtle opacity-70",
+                  )}
+                >
+                  {player.name}
+                </text>
+              );
+            })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -48,6 +48,16 @@ function stepTitle(step: VerlaufStep): string {
   }
 }
 
+/**
+ * Early in a championship almost the whole field is level — seven or eight
+ * names is normal at match one — so the list is capped rather than allowed to
+ * push the readout out of shape.
+ */
+function formatTiedWith(names: string[]): string {
+  if (names.length <= 3) return names.join(", ");
+  return `${names.slice(0, 2).join(", ")} und ${names.length - 2} weiteren`;
+}
+
 type Readout = {
   focus: { name: string; rank: number; points: number; tiedWith: string[] } | null;
   leader: { name: string; points: number } | null;
@@ -169,6 +179,33 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
         width={width}
         height={height}
         role="img"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          // Functional updates, so a held-down arrow key does not lose steps
+          // to a stale closure between renders.
+          switch (event.key) {
+            case "ArrowRight":
+              setActiveStep((step) => Math.min(lastStep, (step ?? -1) + 1));
+              break;
+            case "ArrowLeft":
+              setActiveStep((step) => Math.max(0, (step ?? 1) - 1));
+              break;
+            case "Home":
+              setActiveStep(0);
+              break;
+            case "End":
+              setActiveStep(lastStep);
+              break;
+            case "Escape":
+              setActiveStep(null);
+              return;
+            default:
+              return;
+          }
+          event.preventDefault();
+        }}
+        onBlur={() => setActiveStep(null)}
+        className="focus-visible:outline-accent rounded-sm outline-none focus-visible:outline-2"
         aria-label={
           `Punkteverlauf: Rangentwicklung von ${players.length} Spielern über ` +
           `${playedSteps} gewertete Schritte.` +
@@ -354,6 +391,34 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
         </g>
       </svg>
 
+      {/* The lines carry no text, so the focused player's run is spelled out
+          for screen readers. Only theirs: one table per player would be ~60
+          rows times 18, which helps nobody. */}
+      {focus && (
+        <table className="sr-only">
+          <caption>Rangverlauf von {focus.name}</caption>
+          <thead>
+            <tr>
+              <th scope="col">Schritt</th>
+              <th scope="col">Rang</th>
+              <th scope="col">Punkte</th>
+            </tr>
+          </thead>
+          <tbody>
+            {focus.ranks.map((rank, i) => {
+              const step = steps[i];
+              return (
+                <tr key={i}>
+                  <th scope="row">{step ? stepTitle(step) : `Schritt ${i + 1}`}</th>
+                  <td>{rank}</td>
+                  <td>{focus.points[i]}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
       {activeStep !== null && active && (
         <div
           role="status"
@@ -382,7 +447,7 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
               </p>
               {active.focus.tiedWith.length > 0 && (
                 <p className="text-subtle mt-0.5">
-                  punktgleich mit {active.focus.tiedWith.join(", ")}
+                  punktgleich mit {formatTiedWith(active.focus.tiedWith)}
                 </p>
               )}
               {active.leader && active.leader.name !== active.focus.name && (

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -1,6 +1,8 @@
 import { cx } from "@tipprunde/ui";
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
 
+import { useScopedPath } from "#/components/championship-scope.tsx";
 import type { VerlaufPlayer, VerlaufStep } from "#/lib/verlauf.server.ts";
 
 const ROW_HEIGHT = 22;
@@ -13,6 +15,8 @@ const LABEL_BREAKPOINT = 640;
 const DEFAULT_WIDTH = 900;
 /** Minimum horizontal room per x-axis label before we start skipping some. */
 const LABEL_PITCH = 30;
+/** Half the tooltip's fixed width — it is centred, so this is its clamp. */
+const TOOLTIP_HALF = 104;
 
 interface Props {
   steps: VerlaufStep[];
@@ -31,6 +35,51 @@ function stepLabel(step: VerlaufStep): string {
     case "extraPoints":
       return "ZP";
   }
+}
+
+function stepTitle(step: VerlaufStep): string {
+  switch (step.kind) {
+    case "match":
+      return `Nach Spiel ${step.nr}`;
+    case "roundPoints":
+      return `Rundenpunkte Runde ${step.roundNr}`;
+    case "extraPoints":
+      return "Nach Zusatzpunkten";
+  }
+}
+
+type Readout = {
+  focus: { name: string; rank: number; points: number; tiedWith: string[] } | null;
+  leader: { name: string; points: number } | null;
+};
+
+/** What the crosshair reports at one step: the focused player, and the lead. */
+function buildReadout(
+  players: VerlaufPlayer[],
+  step: number,
+  focusSlug: string | undefined,
+): Readout {
+  const focusPlayer = players.find((p) => p.slug === focusSlug);
+  const leaderPlayer = players.find((p) => p.positions[step] === 0);
+  const rank = focusPlayer?.ranks[step];
+
+  return {
+    focus:
+      focusPlayer && rank !== undefined
+        ? {
+            name: focusPlayer.name,
+            rank,
+            points: focusPlayer.points[step] ?? 0,
+            // The row is unique, the rank is not — so name who shares it.
+            tiedWith: players
+              .filter((p) => p !== focusPlayer && p.ranks[step] === rank)
+              .map((p) => p.name),
+          }
+        : null,
+    leader: leaderPlayer
+      ? { name: leaderPlayer.name, points: leaderPlayer.points[step] ?? 0 }
+      : null,
+  };
 }
 
 /** Width of the element, measured on the client; SSR falls back to a default. */
@@ -62,6 +111,8 @@ function useMeasuredWidth() {
  */
 export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
   const { ref, width } = useMeasuredWidth();
+  const scoped = useScopedPath();
+  const [activeStep, setActiveStep] = useState<number | null>(null);
 
   const showLabels = width >= LABEL_BREAKPOINT;
   const plotWidth = Math.max(
@@ -77,6 +128,8 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
 
   const leader = players[0];
   const focus = players.find((p) => p.slug === focusSlug);
+  /** Labels hang off the last played step, not the plot edge — see below. */
+  const labelX = x(Math.max(0, playedSteps - 1)) + 6;
 
   // Pick x labels that do not collide. Special steps go first so they win the
   // space, and they are walked right-to-left so a final ZP beats an RP sitting
@@ -99,8 +152,19 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
   const line = (player: VerlaufPlayer) =>
     player.positions.map((row, i) => `${x(i)},${y(row)}`).join(" ");
 
+  // Only played steps carry data, so the crosshair never leaves them.
+  const lastStep = Math.max(0, playedSteps - 1);
+  const stepAt = (clientX: number) => {
+    const bounds = ref.current?.getBoundingClientRect();
+    if (!bounds || plotWidth <= 0 || steps.length < 2) return 0;
+    const ratio = (clientX - bounds.left - MARGIN.left) / plotWidth;
+    return Math.min(lastStep, Math.max(0, Math.round(ratio * (steps.length - 1))));
+  };
+
+  const active = activeStep === null ? null : buildReadout(players, activeStep, focusSlug);
+
   return (
-    <div ref={ref} className="w-full">
+    <div ref={ref} className="relative w-full">
       <svg
         width={width}
         height={height}
@@ -185,6 +249,48 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
             />
           )}
 
+          {/* Hit area for the crosshair. Pointer moves only track a mouse —
+              on touch a tap sets the step and it stays put, so dragging over
+              the chart still scrolls the page. */}
+          <rect
+            x={0}
+            y={0}
+            width={plotWidth}
+            height={plotHeight}
+            fill="transparent"
+            onPointerDown={(event) => setActiveStep(stepAt(event.clientX))}
+            onPointerMove={(event) => {
+              if (event.pointerType === "mouse") setActiveStep(stepAt(event.clientX));
+            }}
+            onPointerLeave={(event) => {
+              if (event.pointerType === "mouse") setActiveStep(null);
+            }}
+          />
+
+          {activeStep !== null && (
+            <>
+              <line
+                x1={x(activeStep)}
+                x2={x(activeStep)}
+                y1={0}
+                y2={plotHeight}
+                stroke="currentColor"
+                strokeWidth={1}
+                pointerEvents="none"
+                className="text-app opacity-40"
+              />
+              {focus?.positions[activeStep] !== undefined && (
+                <circle
+                  cx={x(activeStep)}
+                  cy={y(focus.positions[activeStep])}
+                  r={3.5}
+                  pointerEvents="none"
+                  className="text-accent fill-current"
+                />
+              )}
+            </>
+          )}
+
           {/* x axis */}
           {steps.map((step, i) =>
             labelled.has(i) ? (
@@ -212,26 +318,93 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
               const row = player.positions.at(-1);
               if (row === undefined) return null;
               return (
-                <text
+                <Link
                   key={player.userId}
-                  x={x(Math.max(0, playedSteps - 1)) + 6}
-                  y={y(row)}
-                  dominantBaseline="middle"
-                  className={cx(
-                    "fill-current text-[11px]",
-                    player === focus
-                      ? "text-accent font-medium"
-                      : player === leader
-                        ? "text-app"
-                        : "text-subtle opacity-70",
-                  )}
+                  to={scoped(`/verlauf/${player.slug}`)}
+                  preventScrollReset
+                  aria-label={`${player.name} hervorheben`}
+                  className="focus-visible:outline-accent outline-none focus-visible:outline-2"
                 >
-                  {player.name}
-                </text>
+                  {/* The glyphs alone are a poor target, especially on touch. */}
+                  <rect
+                    x={labelX - 3}
+                    y={y(row) - ROW_HEIGHT / 2}
+                    width={LABEL_WIDTH}
+                    height={ROW_HEIGHT}
+                    fill="transparent"
+                  />
+                  <text
+                    x={labelX}
+                    y={y(row)}
+                    dominantBaseline="middle"
+                    className={cx(
+                      "fill-current text-[11px]",
+                      player === focus
+                        ? "text-accent font-medium"
+                        : player === leader
+                          ? "text-app"
+                          : "text-subtle opacity-70 hover:opacity-100",
+                    )}
+                  >
+                    {player.name}
+                  </text>
+                </Link>
               );
             })}
         </g>
       </svg>
+
+      {activeStep !== null && active && (
+        <div
+          role="status"
+          className="border-subtle bg-surface-raised shadow-popover text-app pointer-events-none absolute z-10 w-[13rem] -translate-x-1/2 rounded-md border px-3 py-2 text-xs"
+          style={{
+            left: Math.min(
+              Math.max(MARGIN.left + x(activeStep), TOOLTIP_HALF),
+              Math.max(TOOLTIP_HALF, width - TOOLTIP_HALF),
+            ),
+            // Sit in whichever half the focused line is not in, so the tooltip
+            // never covers the very point being read.
+            top:
+              (focus?.positions[activeStep] ?? 0) < players.length / 2
+                ? MARGIN.top + plotHeight * 0.55
+                : MARGIN.top,
+          }}
+        >
+          <p className="text-muted mb-1 font-medium">{stepTitle(steps[activeStep]!)}</p>
+          {active.focus ? (
+            <>
+              <p>
+                <span className="text-accent font-medium">{active.focus.name}</span>
+                <span className="text-subtle"> · Rang {active.focus.rank} · </span>
+                <span className="tabular-nums">{active.focus.points}</span>
+                <span className="text-subtle"> P</span>
+              </p>
+              {active.focus.tiedWith.length > 0 && (
+                <p className="text-subtle mt-0.5">
+                  punktgleich mit {active.focus.tiedWith.join(", ")}
+                </p>
+              )}
+              {active.leader && active.leader.name !== active.focus.name && (
+                <p className="text-subtle mt-0.5">
+                  Rückstand auf {active.leader.name}:{" "}
+                  <span className="tabular-nums">{active.leader.points - active.focus.points}</span>{" "}
+                  P
+                </p>
+              )}
+            </>
+          ) : (
+            active.leader && (
+              <p>
+                <span className="font-medium">{active.leader.name}</span>
+                <span className="text-subtle"> führt mit </span>
+                <span className="tabular-nums">{active.leader.points}</span>
+                <span className="text-subtle"> P</span>
+              </p>
+            )
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/routes/public/championship/verlauf/index.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/index.tsx
@@ -1,0 +1,78 @@
+import { Link } from "react-router";
+
+import { useScopedPath } from "#/components/championship-scope.tsx";
+import { userContext, viewedChampionshipContext } from "#/lib/context.ts";
+import { getVerlauf } from "#/lib/verlauf.server.ts";
+
+import type { Route } from "./+types/index";
+import { BumpChart } from "./_bump-chart.tsx";
+
+export async function loader({ context, params }: Route.LoaderArgs) {
+  const championship = context.get(viewedChampionshipContext);
+  const user = context.get(userContext);
+
+  if (!championship) return { championship: null, verlauf: null, focusSlug: undefined };
+
+  const verlauf = await getVerlauf(championship.id);
+
+  // The slug is a focus hint, not a resource: an unknown one simply falls
+  // through to the logged-in player, then to the leader (players[0]).
+  const focusSlug =
+    verlauf.players.find((p) => p.slug === params.playerSlug)?.slug ??
+    verlauf.players.find((p) => p.userId === user?.id)?.slug ??
+    verlauf.players[0]?.slug;
+
+  return {
+    championship: { name: championship.name, completed: championship.completed },
+    verlauf,
+    focusSlug,
+  };
+}
+
+export default function Verlauf({ loaderData }: Route.ComponentProps) {
+  const { championship, verlauf, focusSlug } = loaderData;
+  const scoped = useScopedPath();
+
+  if (!championship) {
+    return (
+      <div className="mx-auto w-full max-w-5xl py-8">
+        <title>Punkteverlauf · runde.tips</title>
+        <p className="text-subtle py-16 text-center text-base">Kein aktives Turnier.</p>
+      </div>
+    );
+  }
+
+  const hasData = verlauf !== null && verlauf.playedSteps > 0 && verlauf.players.length > 0;
+
+  return (
+    <div className="mx-auto w-full max-w-5xl py-8">
+      <title>{`Punkteverlauf · ${championship.name} · runde.tips`}</title>
+      <div className="mb-6 flex flex-col items-center gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">{championship.name}</h1>
+        <div className="flex items-center gap-4 text-sm">
+          <Link
+            to={scoped("/tabelle")}
+            prefetch="intent"
+            className="text-subtle hover:text-app focus-visible:ring-accent rounded-sm transition-colors outline-none focus-visible:ring-2"
+          >
+            {championship.completed ? "Abschlusstabelle" : "Aktuelle Tabelle"}
+          </Link>
+          <span className="font-medium">Punkteverlauf</span>
+        </div>
+      </div>
+
+      {hasData ? (
+        <div className="xs:px-2 px-2">
+          <BumpChart
+            steps={verlauf.steps}
+            playedSteps={verlauf.playedSteps}
+            players={verlauf.players}
+            focusSlug={focusSlug}
+          />
+        </div>
+      ) : (
+        <p className="text-subtle py-16 text-center text-base">Noch keine gewerteten Spiele.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/routes/public/championship/verlauf/index.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/index.tsx
@@ -37,7 +37,7 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
   if (!championship) {
     return (
       <div className="mx-auto w-full max-w-5xl py-8">
-        <title>Punkteverlauf · runde.tips</title>
+        <title>Verlauf · runde.tips</title>
         <p className="text-subtle py-16 text-center text-base">Kein aktives Turnier.</p>
       </div>
     );
@@ -48,7 +48,7 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
 
   return (
     <div className="mx-auto w-full max-w-5xl py-8">
-      <title>{`Punkteverlauf · ${championship.name} · runde.tips`}</title>
+      <title>{`Verlauf · ${championship.name} · runde.tips`}</title>
       <div className="mb-6 flex flex-col items-center gap-2">
         <h1 className="text-2xl font-semibold tracking-tight">{championship.name}</h1>
         <div className="flex items-center gap-4 text-sm">
@@ -59,7 +59,7 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
           >
             {championship.completed ? "Abschlusstabelle" : "Aktuelle Tabelle"}
           </Link>
-          <span className="font-medium">Punkteverlauf</span>
+          <span className="font-medium">Verlauf</span>
         </div>
       </div>
 

--- a/apps/web/app/routes/public/championship/verlauf/index.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/index.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 
 import { useScopedPath } from "#/components/championship-scope.tsx";
+import { PlayerSwitch } from "#/components/player-switch.tsx";
 import { userContext, viewedChampionshipContext } from "#/lib/context.ts";
 import { getVerlauf } from "#/lib/verlauf.server.ts";
 
@@ -43,6 +44,7 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
   }
 
   const hasData = verlauf !== null && verlauf.playedSteps > 0 && verlauf.players.length > 0;
+  const focusPlayer = verlauf?.players.find((p) => p.slug === focusSlug);
 
   return (
     <div className="mx-auto w-full max-w-5xl py-8">
@@ -60,6 +62,22 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
           <span className="font-medium">Punkteverlauf</span>
         </div>
       </div>
+
+      {hasData &&
+        focusPlayer && (
+          // The right-edge labels switch the focus on wide screens, but they are
+          // dropped on narrow ones — so this stays visible at every width.
+          <div className="mb-4 flex items-center justify-center gap-1.5 text-sm">
+            <span className="text-subtle">Hervorgehoben:</span>
+            <span className="text-accent font-medium">{focusPlayer.name}</span>
+            <PlayerSwitch
+              players={verlauf.players}
+              currentSlug={focusPlayer.slug}
+              basePath="/verlauf"
+              label="Hervorgehobenen Spieler wechseln"
+            />
+          </div>
+        )}
 
       {hasData ? (
         <div className="xs:px-2 px-2">

--- a/apps/web/app/routes/public/championship/verlauf/index.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/index.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router";
 
 import { useScopedPath } from "#/components/championship-scope.tsx";
-import { PlayerSwitch } from "#/components/player-switch.tsx";
 import { userContext, viewedChampionshipContext } from "#/lib/context.ts";
 import { getVerlauf } from "#/lib/verlauf.server.ts";
 
@@ -44,7 +43,6 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
   }
 
   const hasData = verlauf !== null && verlauf.playedSteps > 0 && verlauf.players.length > 0;
-  const focusPlayer = verlauf?.players.find((p) => p.slug === focusSlug);
 
   return (
     <div className="mx-auto w-full max-w-5xl py-8">
@@ -62,22 +60,6 @@ export default function Verlauf({ loaderData }: Route.ComponentProps) {
           <span className="font-medium">Verlauf</span>
         </div>
       </div>
-
-      {hasData &&
-        focusPlayer && (
-          // The right-edge labels switch the focus on wide screens, but they are
-          // dropped on narrow ones — so this stays visible at every width.
-          <div className="mb-4 flex items-center justify-center gap-1.5 text-sm">
-            <span className="text-subtle">Hervorgehoben:</span>
-            <span className="text-accent font-medium">{focusPlayer.name}</span>
-            <PlayerSwitch
-              players={verlauf.players}
-              currentSlug={focusPlayer.slug}
-              basePath="/verlauf"
-              label="Hervorgehobenen Spieler wechseln"
-            />
-          </div>
-        )}
 
       {hasData ? (
         <div className="xs:px-2 px-2">

--- a/apps/web/app/routes/public/championship/zusatzfragen/_question-block.tsx
+++ b/apps/web/app/routes/public/championship/zusatzfragen/_question-block.tsx
@@ -1,6 +1,6 @@
 import { Disclosure } from "@tipprunde/ui";
 
-import { CellLink } from "#/components/cell-link.tsx";
+import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import type { ExtraQuestion } from "#/lib/extra-questions.server.ts";
 import type { RankedPlayer } from "#/lib/ranking.server.ts";
@@ -50,7 +50,7 @@ export function QuestionBlock({
             return (
               <tr key={player.userId} className="border-subtle border-b last:border-b-0">
                 <td className="xs:px-3 px-2 py-3 font-medium">
-                  <CellLink href={scoped(`/tipps/${player.slug}`)}>{player.name}</CellLink>
+                  <AppLink href={scoped(`/tipps/${player.slug}`)}>{player.name}</AppLink>
                 </td>
                 <td className="xs:px-3 px-2 py-3">{answer?.answer ?? "–"}</td>
                 <td className="xs:px-3 w-px px-2 py-3 text-center tabular-nums">

--- a/docs/verlauf-plan.md
+++ b/docs/verlauf-plan.md
@@ -215,7 +215,7 @@ stands. Entry point is a switcher on the Tabelle view, the same shape the old
 app had:
 
 ```
-Abschlusstabelle · Punkteverlauf
+Abschlusstabelle · Verlauf
 ```
 
 ## Rendering & responsiveness

--- a/docs/verlauf-plan.md
+++ b/docs/verlauf-plan.md
@@ -1,0 +1,312 @@
+# Punkteverlauf — Bump Chart Plan
+
+**Status: designed, not started.** Iteration 1 is deliberately one chart, one
+form. Earlier attempts existed in two now-retired codebases (a TanStack Start
+app using visx, a Svelte app using LayerChart); neither is being ported — see
+"Why not port the old one".
+
+## What this view answers
+
+One question, stated by the user: **how did the ranking evolve over the
+season?** Absolute points and gaps are secondary — worth a possible second
+view later, not part of iteration 1.
+
+That ordering matters, because it picks the chart form. The obvious
+implementation (cumulative points per player over time) answers the secondary
+question well and the primary one only implicitly.
+
+## Why a bump chart, not a points chart — the measurement
+
+The deciding factor is not taste, it is how tightly the field bunches. Measured
+against the dev DB (2026-08-19), counting **how many distinct cumulative point
+values** the players occupy at four checkpoints:
+
+| Championship | Players | Matches | 25% | 50% | 75% | 100% | Largest tie group |
+| ------------ | ------- | ------- | --- | --- | --- | ---- | ----------------- |
+| hr0203       | 10      | 25      | 5   | 6   | 6   | 8    | 4                 |
+| rr0203       | 15      | 49      | 8   | 9   | 11  | 11   | 4                 |
+| hr0304       | 16      | 57      | 11  | 10  | 10  | 11   | 4                 |
+| rr0304       | 18      | 48      | 10  | 13  | 14  | 13   | 4                 |
+| em2004       | 12      | 8 (6)   | 5   | 6   | 9   | 7    | 4                 |
+
+At mid-season, **18 players share 13 distinct values inside a 20-point spread**.
+In a cumulative-points chart that means the lines are not merely close — over
+long stretches they are _exactly coincident_, and up to four players sit on the
+identical value. No amount of color, curve smoothing or opacity fixes that; it
+is a property of the data.
+
+A bump chart spreads the same field across N fixed rows: ~22px between
+neighbours on a 400px plot instead of ~5px, independent of how tight the points
+are. **The user's stated preference and the better rendering choice coincide
+here** — which is why iteration 1 is the bump chart.
+
+## The step axis
+
+The x axis is **not** a match-number scale. It is an ordered list of _steps_,
+each of which is one of:
+
+| Kind          | Label    | When it exists                                         |
+| ------------- | -------- | ------------------------------------------------------ |
+| `match`       | match nr | every match of a **published** round                   |
+| `roundPoints` | `RP`     | after a round's last match, iff that round has entries |
+| `extraPoints` | `ZP`     | once, at the very end, iff extra points are published  |
+
+So a championship with a round rule reads `… 7 · 8 · RP · 9 · 10 · 11 · ZP`.
+
+This resolves the attribution problem cleanly. Round points belong to a round,
+so they get a column exactly where they are awarded. Extra-question points have
+**no round reference in the schema** (`extraQuestions` hangs off the
+championship), so they cannot be distributed over time — they get one final
+column instead. The payoff: **the chart ends exactly on the Abschlusstabelle**,
+with a visible last reshuffle, rather than contradicting it.
+
+Measured expectations, so nobody is surprised:
+
+- `RP` exists only in **hr0304** (the only `torabweichung-bonus-malus` ruleset),
+  there in all four rounds, and only ever `+1`/`−1` for 2–3 players. It is
+  honest and cheap, but visually almost nothing.
+- `ZP` is the significant one: 4 of 5 championships have `mit-zusatzfragen`, and
+  extras run 5–10 points against totals of 55–63 — clearly rank-relevant.
+
+**Unplayed matches still get their step.** The axis is built from all matches of
+published rounds, so it stays stable as the season progresses and shows how far
+along it is. Lines simply stop after the last played step.
+
+## Ties: display position vs. true rank
+
+The ranking table deliberately shows shared ranks (`1, 1, 3` — see
+`sharesRankAbove` in `components/ranking-table.tsx`). A bump chart cannot: two
+players on the same row means overlapping lines, which is the exact problem the
+form was chosen to avoid — and the largest tie group is **4 players in every
+championship measured**.
+
+So the chart carries two different numbers:
+
+- **display position** — unique per player per step, drives the y coordinate
+- **rank** — the real, tie-aware competition rank, shown in the tooltip
+  ("Rang 1, punktgleich mit Olli")
+
+Sort order for the display position:
+
+```
+1. points        desc
+2. previous step's display position  asc
+3. name          asc      (seed for the first step)
+```
+
+Criterion 2 is load-bearing, not cosmetic: it damps the noise. Early on the
+ranks are mostly tie-break artefacts (after two matches, 12 players occupy 5
+distinct values) — carrying the previous position forward keeps a player in
+their row when they get tied, instead of letting them jump alphabetically.
+
+## Layers, not a palette
+
+`packages/theme` is strictly Radix Sand + a single Orange accent. There is no
+categorical palette, and for 10–18 series there should not be one — cycling a
+fixed set of hues (the old visx component cycled 12 colors for up to 18 players)
+means two players share a color, which destroys the one job the color had.
+
+Three layers instead, all expressible in existing tokens:
+
+| Layer         | Who                               | Treatment                       |
+| ------------- | --------------------------------- | ------------------------------- |
+| **Focus**     | resolved player (see Route below) | accent stroke, thickest, on top |
+| **Reference** | the leader / eventual winner      | app-ink stroke, medium          |
+| **Context**   | everyone else                     | muted stroke, thin, low opacity |
+
+Identity never rests on color alone: on wide screens each line is **directly
+labeled at its right edge** with the player's name, which also serves as the
+legend and (per Interaction below) the tap target.
+
+## Where the code lives
+
+Three layers, matching how scoring/ranking is already split:
+
+**`packages/domain/src/progression.ts`** — pure, unit-tested (the package
+already runs `node --experimental-strip-types --test src/*.test.ts`). This is
+where the tricky part lives: accumulation, tie-break, position assignment.
+
+```ts
+export type Step =
+  | { kind: "match"; nr: number }
+  | { kind: "roundPoints"; roundNr: number }
+  | { kind: "extraPoints" };
+
+export type ProgressionInput = {
+  players: { userId: number; name: string }[];
+  steps: Step[];
+  /** Points gained per player at a given step index. */
+  gains: { stepIndex: number; userId: number; points: number }[];
+  /** Steps at or beyond this index have no data yet. */
+  playedSteps: number;
+};
+
+export type PlayerProgression = {
+  userId: number;
+  /** One entry per played step — parallel arrays keep the payload small. */
+  positions: number[]; // 0-based display row, unique per step
+  ranks: number[]; // tie-aware competition rank
+  points: number[]; // cumulative total
+};
+```
+
+**`apps/web/app/lib/verlauf.server.ts`** — the DB touchpoint: published rounds
+and their matches, tips, round points, extra answers; builds `steps` + `gains`
+and calls `calcProgression`. Reuses `hasExtraQuestions` /
+`includesExtraQuestions` from `@tipprunde/domain/ranking` rather than
+re-deriving the gate.
+
+**`apps/web/app/routes/public/championship/verlauf/`** — `index.tsx` (route) and
+a co-located `_bump-chart.tsx`, per the app convention that single-route
+components live beside the route with an `_` prefix. The chart is domain-shaped
+(players, ranks), so it does **not** belong in `@tipprunde/ui`.
+
+### One documented architecture exception
+
+`docs/archiv.md` states the principle: _"Public views are pure display — no
+aggregation at read time."_ This view **must** aggregate at read time — the
+materialized `players` columns only hold end-of-championship totals, never a
+per-step history.
+
+That is accepted deliberately, not overlooked. The largest championship measured
+is 891 tip rows; the whole input is a handful of indexed queries and the
+accumulation is O(steps × players) ≈ 1000 operations. Materializing per-step
+snapshots would mean a new table and a write-path change for a read-rare view —
+far more expensive than the thing it saves.
+
+## Route & navigation
+
+```ts
+route("verlauf/:playerSlug?", "routes/public/championship/verlauf/index.tsx",
+  { id: `${id}-verlauf` }),
+```
+
+Added to `championshipViews()` in `routes.ts`, so it mounts **twice** — the
+running championship at `/verlauf` and every archived one at
+`/archiv/:slug/verlauf` — with no extra work. That also settles the "archive
+only?" question: it is available in both by construction.
+
+`:playerSlug?` mirrors `/tipps/:playerSlug?` and makes a specific player's run
+linkable ("schau dir an, wie ich ab Spiel 30 abgestürzt bin") — the same
+argument `championship-scope-plan.md` makes for keeping secondary content
+addressable rather than modal, with the planned chat in mind.
+
+Focus resolution reuses `resolvePlayer()`: explicit slug → logged-in user →
+rank 1.
+
+**No new header entry** — that constraint from `championship-scope-plan.md`
+stands. Entry point is a switcher on the Tabelle view, the same shape the old
+app had:
+
+```
+Abschlusstabelle · Punkteverlauf
+```
+
+## Rendering & responsiveness
+
+Hand-rolled SVG, no chart dependency. Justification: a chart library earns its
+keep on continuous scales, "nice" tick algorithms, stacking and standard forms —
+**none of which a bump chart uses**. Its y is `position × rowHeight`, its x is
+evenly spaced, and its y axis has no ticks at all. visx would be ~8 packages for
+geometry we are not using; TanStack Charts is headless primitives, so the
+composition work is identical either way.
+
+- **Height is known server-side** (`players × rowHeight` + margins), so it is
+  fixed and there is no layout shift.
+- **Width comes from a `ResizeObserver`**; SSR renders at a default width and
+  the first client frame re-lays-out horizontally only.
+- Straight segments first. Monotone/sigmoid connectors between columns are a
+  refinement, and the first thing to drop if they cause trouble.
+
+### Mobile (decided: drop the labels)
+
+At 375px, right-edge labels eat ~70px, leaving ~6px per column across 48 matches
+— no line is followable. Below the label breakpoint the direct labels are
+**omitted**, which buys back the width; identity then comes from the focus layer
+plus the tooltip, and focus is changed via the switcher.
+
+Horizontal scrolling of the plot was considered and is held back deliberately —
+the user's call was to see (b) working first before adding it.
+
+## Interaction
+
+- **Pointer/tap anywhere in the plot** → nearest step → crosshair + tooltip.
+  Tooltip carries: step label, focused player, true rank (incl. "punktgleich
+  mit …"), cumulative points, gap to the leader.
+- **Tap a right-edge label** → focus that player (navigates to
+  `/verlauf/:playerSlug`, so the focus is linkable). Labels are ~20px tall, an
+  adequate target; the 2px line itself is not.
+- **Mobile**, where labels are absent → the `PlayerSwitch` is the focus control
+  and needs a prominent placement.
+
+## Accessibility
+
+- The chart gets `role="img"` with a summarising `aria-label`.
+- A visually-hidden table gives the **focused player's** per-step rank — bounded
+  (≤ ~60 rows), unlike a full N×steps table.
+- Keyboard: arrow keys move the crosshair between steps.
+- Identity is never color-alone: direct labels on wide screens, tooltip
+  everywhere.
+
+## Migration steps
+
+1. `packages/domain/src/progression.ts` + `progression.test.ts` — accumulation,
+   tie-break, position assignment. Tests cover: shared ranks, the
+   previous-position carry, RP/ZP steps, an unfinished championship.
+2. `apps/web/app/lib/verlauf.server.ts` — queries + step construction.
+3. Route file and `championshipViews()` registration; verify it resolves under
+   both `/verlauf` and `/archiv/:slug/verlauf`.
+4. `_bump-chart.tsx` — static rendering first (lines, layers, axis labels,
+   right-edge labels). No interaction yet.
+5. Interaction: crosshair, tooltip, label tap.
+6. Mobile pass: label breakpoint, switcher placement.
+7. Accessibility pass: hidden table, keyboard stepping, aria labels.
+8. Link from Tabelle; update `apps/web/CLAUDE.md` route list and the docs index
+   in `CLAUDE.md`.
+
+## Alternatives considered
+
+- **Cumulative points chart (the old visx view).** Rejected as the primary form
+  on the measurement above — coincident lines are inherent to this data. Kept as
+  a plausible _second_ view later, deferred out of iteration 1 to see whether it
+  is missed at all.
+- **Rank heatmap** (rows = players, columns = steps). Genuinely strong for this
+  data shape and worth prototyping later; a third view is not iteration 1.
+- **True shared ranks on the y axis.** Would reintroduce 4-way line overlap —
+  the thing the form was chosen to prevent.
+- **Per-round x axis.** Championships have only **4–5 rounds**; that is four
+  data points, not a progression. Per match (25–57) is the right granularity.
+- **Materialized per-step snapshots.** New table + write-path cost for a
+  read-rare view; the read-time aggregation is ~1000 operations.
+
+## Why not port the old one
+
+The retired TanStack app's `punkteverlauf-chart.tsx` works, but three of its
+core decisions do not survive contact with this codebase:
+
+1. **Cycled colors** — 12 hues for up to 18 players; players 1 and 13 collide.
+2. **Color keyed to final rank** — `sortedPlayers` by closing rank, then index →
+   hue. In a running championship a player changes color whenever the standings
+   move; color must follow the entity, never its rank.
+3. **Tip points only** — round points and extra points ignored, so the chart's
+   end contradicts the Abschlusstabelle.
+
+Plus hardcoded hex values against a strict token system. What remains portable
+is the accumulate-and-snapshot idea, which is a dozen lines.
+
+## Decisions taken
+
+| Question                    | Decision                                                    |
+| --------------------------- | ----------------------------------------------------------- |
+| Primary form                | Bump chart (rank evolution)                                 |
+| Points chart as second view | Deferred — iteration 1 is one chart                         |
+| x axis granularity          | Per match, plus RP / ZP special steps                       |
+| Ties                        | Unique display position, true rank in the tooltip           |
+| Tie-break order             | points desc → previous position → name                      |
+| Round / extra points        | Included, as their own steps; chart ends on the final table |
+| Color                       | Three layers in existing tokens; no categorical palette     |
+| Library                     | Hand-rolled SVG, no dependency                              |
+| Route                       | `verlauf/:playerSlug?`, championship-scoped (both branches) |
+| Header nav                  | No new entry — switcher on Tabelle                          |
+| Mobile                      | Drop right-edge labels below the breakpoint                 |
+| Read-time aggregation       | Accepted, documented exception to `archiv.md`               |

--- a/docs/verlauf-plan.md
+++ b/docs/verlauf-plan.md
@@ -1,9 +1,25 @@
 # Punkteverlauf — Bump Chart Plan
 
-**Status: designed, not started.** Iteration 1 is deliberately one chart, one
-form. Earlier attempts existed in two now-retired codebases (a TanStack Start
-app using visx, a Svelte app using LayerChart); neither is being ported — see
-"Why not port the old one".
+**Status: iteration 1 built (2026-08-19).** One chart, one form — deliberately.
+Earlier attempts existed in two now-retired codebases (a TanStack Start app
+using visx, a Svelte app using LayerChart); neither was ported — see "Why not
+port the old one".
+
+Shipped: `calcProgression` in `packages/domain` (unit-tested, and validated
+against every championship in the dev DB — the final step reproduces
+`players.rank` and `players.total` exactly), `getVerlauf` in
+`app/lib/verlauf.server.ts`, and the route plus `_bump-chart.tsx` under
+`routes/public/championship/verlauf/`, reached from Tabelle.
+
+Two things the plan did not anticipate, both found by looking at the rendered
+output and fixed:
+
+- **Labels must hang off the last _played_ step, not the plot edge.** In a
+  running championship the axis reaches into unplayed steps, so edge-anchored
+  labels floated in empty space naming nothing.
+- **Axis labels collide around special steps** (`RP12`, `RPZP`). Special steps
+  now carry a rule line of their own and labels are placed with a minimum gap,
+  so a crowded-out `RP` label still leaves its column marked.
 
 ## What this view answers
 
@@ -247,6 +263,17 @@ the user's call was to see (b) working first before adding it.
 - Keyboard: arrow keys move the crosshair between steps.
 - Identity is never color-alone: direct labels on wide screens, tooltip
   everywhere.
+
+## Open for iteration 2
+
+- **The points view**, if it is ever missed — the measurement above says it
+  will read worse, but that is a prediction, not a verdict.
+- **Rank heatmap** as a third view.
+- **Horizontal scrolling on mobile**, held back deliberately until the
+  label-dropping version had been used.
+- **Curved connectors** between columns; straight segments ship today.
+- The first client frame re-lays-out horizontally, because SSR has no width to
+  measure. Height is known server-side, so nothing jumps vertically.
 
 ## Migration steps
 

--- a/docs/verlauf-plan.md
+++ b/docs/verlauf-plan.md
@@ -17,9 +17,20 @@ output and fixed:
 - **Labels must hang off the last _played_ step, not the plot edge.** In a
   running championship the axis reaches into unplayed steps, so edge-anchored
   labels floated in empty space naming nothing.
-- **Axis labels collide around special steps** (`RP12`, `RPZP`). Special steps
-  now carry a rule line of their own and labels are placed with a minimum gap,
-  so a crowded-out `RP` label still leaves its column marked.
+- **Axis labels collide around special steps** (`RP12`, `RPZP`). Labels are now
+  placed with a minimum gap, and a crowded-out `RP` label still leaves its
+  column marked by the round divider below.
+
+## Round dividers
+
+A vertical divider marks the end of every round — the round's `RP` column where
+it has one, otherwise its last match. It is **not** drawn on the chart's final
+step: a line with nothing after it only boxes the chart in.
+
+That single rule covers the cases without a special case each. `hr0304` keeps a
+divider on each of its four `RP` columns; championships without a round rule get
+the same rhythm off their last matches; and the `ZP` column ends up fenced off
+on its left by the preceding round's divider while staying open on the right.
 
 ## What this view answers
 

--- a/docs/verlauf-plan.md
+++ b/docs/verlauf-plan.md
@@ -257,9 +257,17 @@ the user's call was to see (b) working first before adding it.
 
 ## Interaction
 
-- **Pointer/tap anywhere in the plot** → nearest step → crosshair + tooltip.
-  Tooltip carries: step label, focused player, true rank (incl. "punktgleich
+- **Pointer/tap anywhere in the plot** → nearest step → crosshair, plus a
+  readout carrying: step label, focused player, true rank (incl. "punktgleich
   mit …"), cumulative points, gap to the leader.
+- **The readout is a fixed line above the plot, not a floating tooltip.** It
+  was one at first, positioned in whichever half the focused line was not, so
+  it would never cover the point being read — but the focused line changes
+  halves as you scrub, so the readout jumped and had no position the eye could
+  learn. Worse, on a landscape phone the chart is taller than the viewport and
+  the lower position landed below the fold. It is now sticky under the header,
+  so it stays put while you scroll through the lower ranks, and it always shows
+  a step (the final one at rest) so its line never empties and shifts the chart.
 - **Tap a right-edge label** → focus that player (navigates to
   `/verlauf/:playerSlug`, so the focus is linkable). Labels are ~20px tall, an
   adequate target; the 2px line itself is not.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./progression": "./src/progression.ts",
     "./ranking": "./src/ranking.ts",
     "./rules": "./src/rules.ts",
     "./scoring": "./src/scoring.ts"

--- a/packages/domain/src/progression.test.ts
+++ b/packages/domain/src/progression.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { calcProgression, type ProgressionInput } from "./progression.ts";
+
+/** Anna, Bert, Zoe — deliberately not in alphabetical input order. */
+const players: ProgressionInput["players"] = [
+  { userId: 3, name: "Zoe" },
+  { userId: 1, name: "Anna" },
+  { userId: 2, name: "Bert" },
+];
+
+const at = (result: ReturnType<typeof calcProgression>, userId: number) => {
+  const entry = result.find((e) => e.userId === userId);
+  assert.ok(entry, `no series for user ${userId}`);
+  return entry;
+};
+
+void describe("calcProgression — shape", () => {
+  void it("returns one entry per player, in input order", () => {
+    const result = calcProgression({ players, gains: [], playedSteps: 2 });
+    assert.deepEqual(
+      result.map((e) => e.userId),
+      [3, 1, 2],
+    );
+  });
+
+  void it("produces empty series when nothing has been played", () => {
+    const result = calcProgression({ players, gains: [], playedSteps: 0 });
+    assert.deepEqual(at(result, 1).positions, []);
+    assert.deepEqual(at(result, 1).points, []);
+  });
+
+  void it("covers exactly the played steps, ignoring gains beyond them", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 1, points: 3 },
+        { stepIndex: 5, userId: 1, points: 99 },
+      ],
+      playedSteps: 2,
+    });
+    assert.equal(at(result, 1).points.length, 2);
+    assert.deepEqual(at(result, 1).points, [3, 3]);
+  });
+});
+
+void describe("calcProgression — accumulation", () => {
+  void it("accumulates points across steps", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 1, points: 3 },
+        { stepIndex: 1, userId: 1, points: 2 },
+        { stepIndex: 2, userId: 1, points: 1 },
+      ],
+      playedSteps: 3,
+    });
+    assert.deepEqual(at(result, 1).points, [3, 5, 6]);
+  });
+
+  void it("keeps a player without any gains at 0", () => {
+    const result = calcProgression({
+      players,
+      gains: [{ stepIndex: 0, userId: 1, points: 3 }],
+      playedSteps: 2,
+    });
+    assert.deepEqual(at(result, 2).points, [0, 0]);
+  });
+
+  void it("applies negative gains — round points are +1/-1", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 1, points: 5 },
+        { stepIndex: 1, userId: 1, points: -1 },
+      ],
+      playedSteps: 2,
+    });
+    assert.deepEqual(at(result, 1).points, [5, 4]);
+  });
+
+  void it("sums several gains landing on the same step", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 1, points: 2 },
+        { stepIndex: 0, userId: 1, points: 3 },
+      ],
+      playedSteps: 1,
+    });
+    assert.deepEqual(at(result, 1).points, [5]);
+  });
+});
+
+void describe("calcProgression — ranks vs. display rows", () => {
+  void it("shares a rank on equal points and skips the next", () => {
+    // Anna and Bert on 3, Zoe on 0 → ranks 1, 1, 3.
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 1, points: 3 },
+        { stepIndex: 0, userId: 2, points: 3 },
+      ],
+      playedSteps: 1,
+    });
+    assert.equal(at(result, 1).ranks[0], 1);
+    assert.equal(at(result, 2).ranks[0], 1);
+    assert.equal(at(result, 3).ranks[0], 3);
+  });
+
+  void it("still gives every player a unique display row when ranks are shared", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 1, points: 3 },
+        { stepIndex: 0, userId: 2, points: 3 },
+      ],
+      playedSteps: 1,
+    });
+    const rows = result.map((e) => e.positions[0]);
+    assert.deepEqual(rows.toSorted(), [0, 1, 2]);
+  });
+
+  void it("orders rows by points, best on row 0", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 2, points: 5 },
+        { stepIndex: 0, userId: 1, points: 1 },
+      ],
+      playedSteps: 1,
+    });
+    assert.equal(at(result, 2).positions[0], 0);
+    assert.equal(at(result, 1).positions[0], 1);
+    assert.equal(at(result, 3).positions[0], 2);
+  });
+});
+
+void describe("calcProgression — carry-forward tie-break", () => {
+  void it("seeds the first step alphabetically, not by input order", () => {
+    // Nobody has scored, so the whole field is tied: Anna, Bert, Zoe.
+    const result = calcProgression({ players, gains: [], playedSteps: 1 });
+    assert.equal(at(result, 1).positions[0], 0); // Anna
+    assert.equal(at(result, 2).positions[0], 1); // Bert
+    assert.equal(at(result, 3).positions[0], 2); // Zoe
+  });
+
+  void it("lets a leader keep their row when someone merely catches up", () => {
+    // Zoe leads after step 0; Anna draws level at step 1. Alphabetically Anna
+    // would take row 0 — the carry-forward keeps Zoe there instead.
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 3, points: 3 },
+        { stepIndex: 1, userId: 1, points: 3 },
+      ],
+      playedSteps: 2,
+    });
+    assert.deepEqual(at(result, 3).positions, [0, 0]); // Zoe holds row 0
+    assert.equal(at(result, 1).positions[1], 1); // Anna arrives on row 1
+    // …while the shared rank is reported honestly.
+    assert.equal(at(result, 3).ranks[1], 1);
+    assert.equal(at(result, 1).ranks[1], 1);
+  });
+
+  void it("moves a player up only when they actually go ahead", () => {
+    const result = calcProgression({
+      players,
+      gains: [
+        { stepIndex: 0, userId: 3, points: 3 },
+        { stepIndex: 1, userId: 1, points: 4 },
+      ],
+      playedSteps: 2,
+    });
+    assert.equal(at(result, 1).positions[1], 0); // Anna overtakes
+    assert.equal(at(result, 3).positions[1], 1); // Zoe drops one row
+    assert.equal(at(result, 1).ranks[1], 1);
+    assert.equal(at(result, 3).ranks[1], 2);
+  });
+});

--- a/packages/domain/src/progression.ts
+++ b/packages/domain/src/progression.ts
@@ -1,0 +1,106 @@
+// --- Input / Output ---
+
+export type ProgressionInput = {
+  /** Enrolled players — every one gets a row, even without a single point. */
+  players: { userId: number; name: string }[];
+  /**
+   * Points a player gained at one step. Steps a player did not score in are
+   * simply absent; entries outside the played range are ignored.
+   */
+  gains: { stepIndex: number; userId: number; points: number }[];
+  /** How many leading steps have data. The result covers exactly these. */
+  playedSteps: number;
+};
+
+export type PlayerProgression = {
+  userId: number;
+  /**
+   * Display row per step, 0-based and **unique** — this drives the y
+   * coordinate. Not the rank: tied players must not share a row, or their
+   * lines would coincide, which is the whole point of the bump chart.
+   */
+  positions: number[];
+  /** Tie-aware competition rank per step, 1-based. Equal totals share a rank. */
+  ranks: number[];
+  /** Cumulative total per step. */
+  points: number[];
+};
+
+// --- Progression ---
+
+/**
+ * Turn per-step point gains into a bump-chart series per player: cumulative
+ * points, the tie-aware rank, and a unique display row.
+ *
+ * The display row carries the previous step's row forward as its tie-break,
+ * which is what keeps the chart readable. Early on, ranks are mostly
+ * tie-break artefacts — a whole field can sit on two or three distinct
+ * totals — and breaking those ties by name would make players jump rows for
+ * no reason at all. Carrying the previous row forward keeps a player where
+ * they were when someone merely catches up to them.
+ *
+ * Names only seed the very first step, where there is no previous row yet.
+ *
+ * Returns one entry per input player, in input order.
+ *
+ * See docs/verlauf-plan.md.
+ */
+export function calcProgression({
+  players,
+  gains,
+  playedSteps,
+}: ProgressionInput): PlayerProgression[] {
+  const stepCount = Math.max(0, playedSteps);
+
+  // Bucket by step so each step only walks its own gains.
+  const gainsByStep: { userId: number; points: number }[][] = Array.from(
+    { length: stepCount },
+    () => [],
+  );
+  for (const gain of gains) {
+    if (gain.stepIndex >= 0 && gain.stepIndex < stepCount) {
+      gainsByStep[gain.stepIndex]?.push(gain);
+    }
+  }
+
+  const cumulative = new Map(players.map((p) => [p.userId, 0]));
+
+  // Seed the carry-forward order alphabetically — at step one everyone is on
+  // 0 points, so without a seed the first row assignment would follow input
+  // order, which is arbitrary.
+  const row = new Map(
+    players.toSorted((a, b) => a.name.localeCompare(b.name, "de")).map((p, i) => [p.userId, i]),
+  );
+
+  const series = new Map<number, PlayerProgression>(
+    players.map((p) => [p.userId, { userId: p.userId, positions: [], ranks: [], points: [] }]),
+  );
+
+  for (let step = 0; step < stepCount; step++) {
+    for (const gain of gainsByStep[step] ?? []) {
+      cumulative.set(gain.userId, (cumulative.get(gain.userId) ?? 0) + gain.points);
+    }
+
+    const order = players.toSorted((a, b) => {
+      const byPoints = (cumulative.get(b.userId) ?? 0) - (cumulative.get(a.userId) ?? 0);
+      return byPoints !== 0 ? byPoints : (row.get(a.userId) ?? 0) - (row.get(b.userId) ?? 0);
+    });
+
+    let rank = 1;
+    order.forEach((player, index) => {
+      const points = cumulative.get(player.userId) ?? 0;
+      const ahead = index > 0 ? (cumulative.get(order[index - 1]!.userId) ?? 0) : points;
+      if (points !== ahead) rank = index + 1;
+
+      row.set(player.userId, index);
+      const entry = series.get(player.userId);
+      entry?.positions.push(index);
+      entry?.ranks.push(rank);
+      entry?.points.push(points);
+    });
+  }
+
+  return players.map(
+    (p) => series.get(p.userId) ?? { userId: p.userId, positions: [], ranks: [], points: [] },
+  );
+}


### PR DESCRIPTION
## Summary

Rank progression per championship, as a bump chart. Design and reasoning: [docs/verlauf-plan.md](../blob/feat/punkteverlauf/docs/verlauf-plan.md).

**Why a bump chart and not the obvious cumulative-points chart:** measured against the dev DB, at mid-season 18 players share 13 distinct point values inside a 20-point spread — a points chart draws *coincident* lines over long stretches. That is a property of the data, not of the rendering. A bump chart spreads the same field over N fixed rows regardless.

**Layers instead of a palette.** The theme is Sand plus one accent, and 10–18 cycled hues would collide anyway: focused player in accent, leader in app ink, everyone else muted. Names are labelled directly at each line's end.

**Step axis**, not a match-number scale: every match of a published round, an `RP` step after any round that awarded bonus/malus, and a final `ZP` step — so the chart ends exactly on the Abschlusstabelle instead of contradicting it.

**No chart dependency.** A bump chart's y is `row × rowHeight` and its x is evenly spaced, so the scales, tick logic and axis rendering a library brings along would all go unused.

## Please check on device

Touch is the part I could not verify properly:

- Tapping the plot sets the crosshair; **dragging across the chart should still scroll the page** (pointer moves only track a mouse, by design).
- Below 640px the right-edge name labels are dropped — the `Hervorgehoben: … ⌄` switcher above the chart is then the only way to change the highlighted player.
- Worth a look at `/archiv/rr0304/verlauf` (18 players, the densest case) and `/verlauf` (running championship, lines stop at step 6 of 8).

## Verification so far

- `calcProgression` has 14 unit tests, and was validated against every championship in the dev DB: the final step reproduces `players.rank` and `players.total` exactly, including hr0304's four RP steps and the still-running em2004.
- Rendering checked on desktop and mobile widths, light and dark, completed and running championships.
- `pnpm --filter web typecheck` and `pnpm --filter domain test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)