### PR TITLE
docs: Bring the docs in line with reality before 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.0.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v0.28.0...v1.0.0)
+
+### 📖 Documentation
+
+- Bring the docs in line with reality before 1.0 ([c79a96b](https://github.com/haus23/tipprunde/commit/c79a96b))
+- Record next.runde.tips moving to Railway, and go realtime for chat ([5461458](https://github.com/haus23/tipprunde/commit/5461458))
+- Correct the CF Worker's reachability, settle chat on WebSockets ([c50b0e5](https://github.com/haus23/tipprunde/commit/c50b0e5))
+- Split docs into living reference and dated decisions ([9918876](https://github.com/haus23/tipprunde/commit/9918876))
+- Correct what counts as a breaking change ([459d5bd](https://github.com/haus23/tipprunde/commit/459d5bd))
+
 ## v0.28.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v0.27.1...v0.28.0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,18 +56,24 @@ The same pattern works for any package script (`build`, `typecheck`, etc.).
 
 Shared documentation in `docs/`:
 
+**Reference — kept current as the code changes:**
+
 - `domain.md` — Domain model: championship/round feature flags, ruleset rule IDs, scoring chain
 - `theme.md` — Color system: Radix Sand/Orange tokens, `@tipprunde/theme` package usage
 - `tokens.md` — Design tokens: breakpoints, easing, shadows, border-radius, typography scale
 - `deployment.md` — Railway service + environments, environment variables, first-deploy bootstrap
 - `web-shell.md` — Public shell: header contents, nav strategy, planned docked/drawer chat panel
-- `color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm, SSR constraint
-- `archiv.md` — Archiv feature: ranking columns on `players`, dashboard entry (built — `/archiv`, `/archiv/:slug`)
-- `championship-scope-plan.md` — Championship as a URL dimension so Archiv and current-season views share route files; dashboard is the shared championship overview (built)
-- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (built)
-- `chat-plan.md` — Planned in-app chat: separate DB, phased transport (polling → SSE/WS on Railway), TanStack Virtual (not yet built)
-- `app-merge.md` — History: how the TanStack Start app merged into the RR8 app (phases A–D, done 2026-08-09); step 1 of merge → Railway → Litestream
-- `railway-plan.md` — Prod hosting: single Node service on Railway (done, live); the SQLite+Litestream step is deferred unless Turso's free tier runs out
+- `archiv.md` — Archiv feature: ranking columns on `players`, dashboard entry
+
+**Decisions (`docs/decisions/`) — dated records of why something is the way it
+is. Superseded, never quietly rewritten:**
+
+- `01-chat.md` — In-app chat: separate DB, WebSocket transport, TanStack Virtual (not built)
+- `02-hosting-railway.md` — Single Node service on Railway (live); SQLite+Litestream deferred unless Turso's free tier runs out
+- `03-color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm
+- `04-app-merge.md` — How the TanStack Start app merged into the RR8 app (done 2026-08-09)
+- `05-championship-scope.md` — Championship as a URL dimension; Archiv and current season share route files
+- `06-verlauf-bump-chart.md` — Punkteverlauf as a bump chart, and the measurement that picked that form
 
 ## Skills
 
@@ -99,5 +105,5 @@ pnpx changelogen --noAuthors --release -r 1.0.0 --push
 
 **What counts as breaking here.** There is no public API, so it comes down to
 three things: public URLs (links are shared and bookmarked — see
-`chat-plan.md`), the DB schema, and the session/cookie format. Changing any of
+`01-chat.md`), the DB schema, and the session/cookie format. Changing any of
 those is a major.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,18 @@ For a one-off jump to an exact version, `-r` sets it explicitly:
 pnpx changelogen --noAuthors --release -r 1.0.0 --push
 ```
 
-**What counts as breaking here.** There is no public API, so it comes down to
-three things: public URLs (links are shared and bookmarked — see
-`01-chat.md`), the DB schema, and the session/cookie format. Changing any of
-those is a major.
+**What counts as breaking here.** There is no public API, so the test is simply:
+_does something that already worked stop working?_
+
+- **Public URLs** — a shared or bookmarked link 404s. Links get passed around
+  (see `01-chat.md`), so this is the one most likely to bite someone.
+- **Session / cookie format** — everyone is logged out. Happened once already,
+  at the app merge (see `04-app-merge.md`).
+- **The DB schema, but only when the change is destructive** — dropping or
+  renaming a column, changing what an existing one means, a migration that
+  existing rows cannot survive.
+
+**Adding to the schema is a feature, not a break.** A new ruleset that needs
+new columns or new rule IDs supports something new while everything old keeps
+working exactly as before — that is a **minor**. Expect this to be the common
+case: the rulesets drive the domain, and they grow by addition.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,15 +59,15 @@ Shared documentation in `docs/`:
 - `domain.md` — Domain model: championship/round feature flags, ruleset rule IDs, scoring chain
 - `theme.md` — Color system: Radix Sand/Orange tokens, `@tipprunde/theme` package usage
 - `tokens.md` — Design tokens: breakpoints, easing, shadows, border-radius, typography scale
-- `deployment.md` — Environment variables, first-deploy bootstrap, user management
+- `deployment.md` — Railway service + environments, environment variables, first-deploy bootstrap
 - `web-shell.md` — Public shell: header contents, nav strategy, planned docked/drawer chat panel
 - `color-scheme.md` — Single-button light/dark switch: stored vs. resolved state, click algorithm, SSR constraint
 - `archiv.md` — Archiv feature: ranking columns on `players`, dashboard entry (built — `/archiv`, `/archiv/:slug`)
 - `championship-scope-plan.md` — Championship as a URL dimension so Archiv and current-season views share route files; dashboard is the shared championship overview (built)
-- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (iteration 1 built)
+- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (built)
 - `chat-plan.md` — Planned in-app chat: separate DB, phased transport (polling → SSE/WS on Railway), TanStack Virtual (not yet built)
 - `app-merge.md` — History: how the TanStack Start app merged into the RR8 app (phases A–D, done 2026-08-09); step 1 of merge → Railway → Litestream
-- `railway-plan.md` — **Next up.** Planned prod hosting: single Node service on Railway, SQLite file + Litestream→R2, cost breakdown (steps 2/3)
+- `railway-plan.md` — Prod hosting: single Node service on Railway (done, live); the SQLite+Litestream step is deferred unless Turso's free tier runs out
 
 ## Skills
 
@@ -78,8 +78,26 @@ After adding or changing interactive UI elements (buttons, popovers, accordions,
 ## Release (from repo root):
 
 ```bash
-# Patch version change: 0.1.2 -> 0.1.3  (It's a minor release arg due to major version 0)
+# Fix:      1.0.0 -> 1.0.1
+pnpx changelogen --noAuthors --release --patch --push
+# Feature:  1.0.0 -> 1.1.0
 pnpx changelogen --noAuthors --release --minor --push
-# Minor version change: 0.1.2 -> 0.2.0  (It's a major release arg due to major version 0)
+# Breaking: 1.0.0 -> 2.0.0
 pnpx changelogen --noAuthors --release --major --push
 ```
+
+Release **after** the PR's check is green but **before** merging, on the PR
+branch — the release commit rides along and production deploys once instead of
+twice. Merge with `--merge`, never `--rebase`: a rebase rewrites the commits,
+which would leave the tag pointing at a commit `main` never took.
+
+For a one-off jump to an exact version, `-r` sets it explicitly:
+
+```bash
+pnpx changelogen --noAuthors --release -r 1.0.0 --push
+```
+
+**What counts as breaking here.** There is no public API, so it comes down to
+three things: public URLs (links are shared and bookmarked — see
+`chat-plan.md`), the DB schema, and the session/cookie format. Changing any of
+those is a major.

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -2,7 +2,9 @@
 
 ## Project description
 
-This is the app behind https://runde.tips - the Haus23 Tipprunde. It is a React Router 8 Framework Mode application. Public routes live at the root, the management UI (championships, players, matches, teams, leagues, results, tips, rulesets) under `/manager`.
+This is the Haus23 Tipprunde. It is a React Router 8 Framework Mode application. Public routes live at the root, the management UI (championships, players, matches, teams, leagues, results, tips, rulesets) under `/manager`.
+
+It serves **https://next.runde.tips** from the Railway production deployment. The apex **https://runde.tips** still belongs to the legacy stack and moves here at go-live, once the 2002–now history is fully entered — at which point `next.` goes away. So: anything about "production" in here means this app's own deployment, not the site real users are on today.
 
 ## Commands
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -20,7 +20,7 @@ This app reads and writes the DB with drizzle-orm. No drizzle-kit setup here.
 
 ## Architecture
 
-**Stack:** React Router 8 (Framework Mode) + React Aria Components + Tailwind CSS 4 + Drizzle ORM + Turso (libSQL/SQLite) + Cloudflare Workers
+**Stack:** React Router 8 (Framework Mode) + React Aria Components + Tailwind CSS 4 + Drizzle ORM + Turso (libSQL/SQLite), served by a custom Node server (`server/app.ts`) on Railway
 
 **App directory layout (`app/`):**
 
@@ -106,12 +106,12 @@ Shared docs are in the root `docs/` folder:
 - `domain.md` — Domain model: championship/round feature flags, ruleset rule IDs, scoring chain logic
 - `theme.md` — Color system: Radix Sand/Orange tokens, `--color-*` CSS properties, Tailwind setup
 - `tokens.md` — Design tokens: breakpoints, easing, shadows, border-radius, typography scale
-- `deployment.md` — Environment variables (full table), first-deploy bootstrap (manual admin user insert), user management
+- `deployment.md` — Railway service + environments, environment variables (full table), first-deploy bootstrap (manual admin user insert)
 - `web-shell.md` — Public shell: header contents, nav strategy, planned chat panel
 - `color-scheme.md` — Single-button light/dark switch spec (replaces both current controls)
 - `archiv.md` — Archiv: the materialized ranking columns on `players` and what depends on them
 - `championship-scope-plan.md` — Public-routing change: championship as a URL dimension, shared route files for Archiv + current season, dashboard as the shared overview (built)
-- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (iteration 1 built)
+- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (built)
 - `app-merge.md` — History: how this app absorbed the separate web app (why things look the way they do)
 
 ## Environment variables
@@ -123,9 +123,8 @@ mail and code settings, not just the DB:
 `RESEND_API_KEY`, `FROM_EMAIL`, `TOTP_EXPIRES_IN`, `TOTP_MAX_ATTEMPTS`,
 `SESSION_DURATION_DEFAULT`, `SESSION_DURATION_REMEMBER`
 
-In production the first five are Worker **secrets** and the rest are `vars` in
-`wrangler.jsonc`, which also lists them in `secrets.required` so a deploy fails
-by name when one is missing. See `docs/deployment.md`.
+In production they are set per Railway environment. The first five are
+secrets and never belong in the repo. See `docs/deployment.md`.
 
 ## External Documentation (LLM-Ready)
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -43,14 +43,14 @@ Public routes live at the root; the manager sits under `/manager`.
 
 The championship-scoped views below are mounted **twice** from one set of
 files — at the root for the running championship, and under `/archiv/:slug`
-for any other published one (see `championship-scope-plan.md`):
+for any other published one (see `05-championship-scope.md`):
 
 - `/` — Championship overview: standings, current matches, ruleset
 - `/tabelle` — Current/final table
 - `/spiele`, `/spiele/:nr` — Match overview (accordion) and per-match tips
 - `/tipps/:playerSlug?` — One player's tips (defaults to self, else rank 1)
 - `/verlauf/:playerSlug?` — Rank progression bump chart; the slug only picks
-  the highlighted line (see `verlauf-plan.md`)
+  the highlighted line (see `06-verlauf-bump-chart.md`)
 - `/zusatzfragen` — Extra questions and answers
 - `/regelwerk` — The championship's ruleset in full
 
@@ -97,24 +97,31 @@ Cross-championship, outside that scope:
 - All Tailwind default colors are disabled — use only `--color-*` tokens from `app/app.css` (Radix Sand + Orange palette)
 - German locale (`de-DE`) is hardcoded via `I18nProvider`; use `formatDate()` / `slugify()` from `app/lib/utils.ts`
 - Middleware is default behaviour in RR8 (the `v8_*` future flags are gone); `context` is a `RouterContextProvider`
-- One fetcher per independently-savable row — never share a `useFetcher()` across a list (see `docs/app-merge.md` history and the grid routes)
+- One fetcher per independently-savable row — never share a `useFetcher()` across a list (see `docs/decisions/04-app-merge.md` history and the grid routes)
 - Errors that should **render** are thrown from a loader, never from middleware — a `data()` thrown in middleware short-circuits as a raw response body and never reaches an `ErrorBoundary`. `redirect()` from middleware is fine.
 - Mount an `ErrorBoundary` on a **child** route, not on the layout whose chrome should survive the error — a layout-level boundary replaces that layout. Public 404s go through `public/_layout.tsx` + the `*` route, manager 404s through `manager/_not-found.tsx` and `manager/championship/_layout.tsx`.
 
 ## Docs
 
-Shared docs are in the root `docs/` folder:
+Shared docs are in the root `docs/` folder.
+
+**Reference — kept current as the code changes:**
 
 - `domain.md` — Domain model: championship/round feature flags, ruleset rule IDs, scoring chain logic
 - `theme.md` — Color system: Radix Sand/Orange tokens, `--color-*` CSS properties, Tailwind setup
 - `tokens.md` — Design tokens: breakpoints, easing, shadows, border-radius, typography scale
-- `deployment.md` — Railway service + environments, environment variables (full table), first-deploy bootstrap (manual admin user insert)
+- `deployment.md` — Railway service + environments, environment variables (full table), first-deploy bootstrap
 - `web-shell.md` — Public shell: header contents, nav strategy, planned chat panel
-- `color-scheme.md` — Single-button light/dark switch spec (replaces both current controls)
 - `archiv.md` — Archiv: the materialized ranking columns on `players` and what depends on them
-- `championship-scope-plan.md` — Public-routing change: championship as a URL dimension, shared route files for Archiv + current season, dashboard as the shared overview (built)
-- `verlauf-plan.md` — Punkteverlauf: bump chart of rank evolution, step axis with RP/ZP columns, hand-rolled SVG (built)
-- `app-merge.md` — History: how this app absorbed the separate web app (why things look the way they do)
+
+**Decisions (`docs/decisions/`) — dated records of why something is the way it is:**
+
+- `01-chat.md` — In-app chat: separate DB, WebSocket transport (not built)
+- `02-hosting-railway.md` — Railway hosting, custom Node server
+- `03-color-scheme.md` — Single-button light/dark switch spec
+- `04-app-merge.md` — How this app absorbed the separate web app (why things look the way they do)
+- `05-championship-scope.md` — Championship as a URL dimension, shared route files for Archiv + current season
+- `06-verlauf-bump-chart.md` — Punkteverlauf as a bump chart, hand-rolled SVG
 
 ## Environment variables
 

--- a/apps/web/app/components/color-scheme-toggle.tsx
+++ b/apps/web/app/components/color-scheme-toggle.tsx
@@ -1,6 +1,6 @@
 // Single-button color-scheme switch, shared by both shells.
 // Three stored states (system / light / dark), only two ever shown.
-// See docs/color-scheme.md for the model and the state table.
+// See docs/decisions/03-color-scheme.md for the model and the state table.
 import { Button } from "@tipprunde/ui";
 import { MoonIcon, SunIcon } from "lucide-react";
 import { useFetcher } from "react-router";

--- a/apps/web/app/lib/archiv.server.ts
+++ b/apps/web/app/lib/archiv.server.ts
@@ -93,7 +93,7 @@ export async function getEwigeTabelle() {
  * `_championship-layout.tsx`.
  *
  * `published`, not `completed`: visibility and "finished" are orthogonal
- * (see docs/championship-scope-plan.md). The running championship is
+ * (see docs/decisions/05-championship-scope.md). The running championship is
  * reachable this way too — a harmless coincidence, not a special case to
  * guard against.
  */

--- a/apps/web/app/lib/championship.server.ts
+++ b/apps/web/app/lib/championship.server.ts
@@ -27,7 +27,7 @@ export async function getChampionships() {
  * Every publicly visible championship, for the season switcher — same
  * `published: true` rule as `getPublishedChampionship`. `completed` plays no
  * part: it means "finished", not "hidden". See
- * docs/championship-scope-plan.md.
+ * docs/decisions/05-championship-scope.md.
  */
 export async function getPublicChampionships() {
   return db.query.championships.findMany({

--- a/apps/web/app/lib/verlauf.server.ts
+++ b/apps/web/app/lib/verlauf.server.ts
@@ -49,7 +49,7 @@ export type Verlauf = {
  * materialized `players` columns only hold end-of-championship totals, never a
  * per-step history. That is a deliberate, documented exception: the largest
  * championship is under 900 tip rows, so this is four indexed queries and a
- * pass over ~1000 gains. See docs/verlauf-plan.md.
+ * pass over ~1000 gains. See docs/decisions/06-verlauf-bump-chart.md.
  */
 export async function getVerlauf(championshipId: number): Promise<Verlauf> {
   const [championship, enrolled, publishedRounds, tipRows, roundPointRows, extraRows] =

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -17,7 +17,7 @@ import { type RouteConfig, index, layout, route } from "@react-router/dev/routes
  * `viewedChampionshipContext` and never learn which branch rendered them, so a
  * new public feature is written once and appears in both.
  *
- * See docs/championship-scope-plan.md.
+ * See docs/decisions/05-championship-scope.md.
  */
 const championshipViews = (id: string) => [
   index("routes/public/championship/index.tsx", { id: `${id}-index` }),
@@ -30,7 +30,7 @@ const championshipViews = (id: string) => [
   route("tipps/:playerSlug?", "routes/public/championship/tipps/index.tsx", {
     id: `${id}-tipps`,
   }),
-  // :playerSlug only picks the highlighted line — see docs/verlauf-plan.md.
+  // :playerSlug only picks the highlighted line — see docs/decisions/06-verlauf-bump-chart.md.
   route("verlauf/:playerSlug?", "routes/public/championship/verlauf/index.tsx", {
     id: `${id}-verlauf`,
   }),

--- a/apps/web/app/routes/public/_championship-layout.tsx
+++ b/apps/web/app/routes/public/_championship-layout.tsx
@@ -10,7 +10,7 @@ import type { Route } from "./+types/_championship-layout";
  * Root branch of the shared championship views — everything below is scoped to
  * the **running** championship (latest published). The archive branch is
  * `archiv/_layout.tsx`; both mount the same view files, see
- * docs/championship-scope-plan.md.
+ * docs/decisions/05-championship-scope.md.
  *
  * Renders no chrome of its own: each view already carries its own heading and
  * names the championship, so anything here would only duplicate it.

--- a/apps/web/app/routes/public/archiv/_layout.tsx
+++ b/apps/web/app/routes/public/archiv/_layout.tsx
@@ -17,7 +17,7 @@ const navLinkClass =
 /**
  * Archive branch of the shared championship views — scoped to the championship
  * named by :slug. The root branch is `_championship-layout.tsx`; both mount the
- * same view files, see docs/championship-scope-plan.md.
+ * same view files, see docs/decisions/05-championship-scope.md.
  *
  * Chrome here is only what the root branch does *not* need: getting back out of
  * the archive, and moving between seasons. The championship itself is named by

--- a/apps/web/app/routes/public/championship/_switcher.tsx
+++ b/apps/web/app/routes/public/championship/_switcher.tsx
@@ -39,11 +39,11 @@ const normalize = (s: string) =>
  * Season switcher next to the championship name — mirrors MatchSwitch /
  * PlayerSwitch (chevron-only trigger, Autocomplete popover). Search earns its
  * keep here specifically: the list only has 5 entries today, but two decades
- * of legacy seasons are still being imported (see docs/railway-plan.md).
+ * of legacy seasons are still being imported (see docs/decisions/02-hosting-railway.md).
  *
  * Lives on the shared championship overview (championship/index.tsx), so it
  * appears once for the running season and once per archived one — the same
- * file, per docs/championship-scope-plan.md. This is the only way in and out
+ * file, per docs/decisions/05-championship-scope.md. This is the only way in and out
  * of the Archiv; there is deliberately no header nav entry for it.
  */
 export function ChampionshipSwitcher({ championships, currentSlug, triggerClassName }: Props) {

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -128,7 +128,7 @@ function useMeasuredWidth() {
  *
  * Rows are display rows, not ranks — tied players share a rank but never a
  * row, or their lines would coincide. `calcProgression` assigns them; see
- * docs/verlauf-plan.md.
+ * docs/decisions/06-verlauf-bump-chart.md.
  */
 export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
   const { ref, width } = useMeasuredWidth();

--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -12,7 +12,7 @@ type NodeMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => vo
 // Railway target — replaces the Cloudflare Workers `workers/app.ts` entry.
 // Deliberately a small hand-rolled server, not `@react-router/serve`: chat v2
 // needs raw access to the HTTP server to attach SSE/WS, so this is built once
-// rather than swapped twice. See docs/railway-plan.md.
+// rather than swapped twice. See docs/decisions/02-hosting-railway.md.
 
 const PORT = Number(process.env.PORT) || 3000;
 

--- a/docs/archiv.md
+++ b/docs/archiv.md
@@ -10,7 +10,7 @@ with an all-time table, and a final table per championship.
 > `/archiv/:slug`, distinguished only by route id. The dashboard is the shared
 > per-championship overview; the Archiv sub-nav is gone, replaced by the
 > header nav plus a season switcher on the championship name. See
-> [championship-scope-plan.md](./championship-scope-plan.md). **The routes
+> [05-championship-scope.md](./decisions/05-championship-scope.md). **The routes
 > described below are stale** — kept for the data design (materialized
 > ranking columns), which is unaffected and stays valid.
 

--- a/docs/chat-plan.md
+++ b/docs/chat-plan.md
@@ -8,9 +8,29 @@ discussion so the feature can start without re-deriving them.
 > while the app ran on CF Workers with Railway as a future step. Railway is the
 > host now, so wherever this doc phases something as "now (CF Workers)" versus
 > "later (Railway)", the later column is simply the present — the CF-Workers
-> phase never has to be built. In particular the transport can go straight to
-> SSE/WS instead of starting with polling. What has _not_ changed is the
-> storage decision: a separate database, not a second schema in the domain DB.
+> phase never has to be built. What has _not_ changed is the storage decision:
+> a separate database, not a second schema in the domain DB.
+>
+> **Decided 2026-08-20: skip the polling phase, go realtime directly.**
+> Railway bills resources, not requests or connections
+> ([pricing](https://docs.railway.com/reference/pricing): $10/GB-month memory,
+> $20/vCPU-month, $0.05/GB egress), so at a handful of users neither option
+> registers against the $5 credit. Cost is simply not the deciding factor here;
+> polling's real cost is querying the database around the clock for nothing.
+>
+> **But this reverses the SSE-over-WebSockets preference below**, which assumed
+> SSE was the lower-effort path. On Railway that is not true
+> ([SSE vs WebSockets](https://docs.railway.com/guides/sse-vs-websockets)):
+> SSE rides on a normal HTTP response and inherits the request limits — closed
+> after **5 minutes without data**, capped at **15 minutes** even with
+> heartbeats, so it needs heartbeat comment lines _and_ reconnect-on-cap
+> handling. **WebSockets are exempt from those timeouts and may stay open
+> indefinitely, idle included.** The custom Node server (`server/app.ts`) that
+> WS needs already exists — it was built in the Railway move, partly for this.
+> Either way the client needs reconnect logic, because deploys drop
+> connections.
+>
+> Unchanged either way: **Railway app sleeping must stay off.**
 
 Chat lands in the single RR8 app (`apps/web`) — the merge that made it single
 is done ([app-merge.md](./app-merge.md)). The shell/layout side (docked rail vs.

--- a/docs/chat-plan.md
+++ b/docs/chat-plan.md
@@ -4,6 +4,14 @@
 This doc records the architecture decisions and reasoning from the 2026-07
 discussion so the feature can start without re-deriving them.
 
+> **The hosting premise below has already changed (2026-08-20).** It was written
+> while the app ran on CF Workers with Railway as a future step. Railway is the
+> host now, so wherever this doc phases something as "now (CF Workers)" versus
+> "later (Railway)", the later column is simply the present — the CF-Workers
+> phase never has to be built. In particular the transport can go straight to
+> SSE/WS instead of starting with polling. What has _not_ changed is the
+> storage decision: a separate database, not a second schema in the domain DB.
+
 Chat lands in the single RR8 app (`apps/web`) — the merge that made it single
 is done ([app-merge.md](./app-merge.md)). The shell/layout side (docked rail vs.
 drawer, keep-mounted constraint) is specced in

--- a/docs/chat-plan.md
+++ b/docs/chat-plan.md
@@ -18,17 +18,17 @@ discussion so the feature can start without re-deriving them.
 > registers against the $5 credit. Cost is simply not the deciding factor here;
 > polling's real cost is querying the database around the clock for nothing.
 >
-> **But this reverses the SSE-over-WebSockets preference below**, which assumed
-> SSE was the lower-effort path. On Railway that is not true
-> ([SSE vs WebSockets](https://docs.railway.com/guides/sse-vs-websockets)):
+> **And the transport is WebSockets, not SSE** — reversing the preference
+> stated below, which assumed SSE was the lower-effort path. On Railway it is
+> not ([SSE vs WebSockets](https://docs.railway.com/guides/sse-vs-websockets)):
 > SSE rides on a normal HTTP response and inherits the request limits — closed
 > after **5 minutes without data**, capped at **15 minutes** even with
-> heartbeats, so it needs heartbeat comment lines _and_ reconnect-on-cap
+> heartbeats — so it would need heartbeat comment lines _and_ reconnect-on-cap
 > handling. **WebSockets are exempt from those timeouts and may stay open
-> indefinitely, idle included.** The custom Node server (`server/app.ts`) that
-> WS needs already exists — it was built in the Railway move, partly for this.
-> Either way the client needs reconnect logic, because deploys drop
-> connections.
+> indefinitely, idle included.** The one argument for SSE was avoiding custom
+> server glue, and that server (`server/app.ts`) already exists from the
+> Railway move. The client still needs reconnect logic either way, because
+> deploys drop connections.
 >
 > Unchanged either way: **Railway app sleeping must stay off.**
 

--- a/docs/decisions/01-chat.md
+++ b/docs/decisions/01-chat.md
@@ -33,9 +33,9 @@ discussion so the feature can start without re-deriving them.
 > Unchanged either way: **Railway app sleeping must stay off.**
 
 Chat lands in the single RR8 app (`apps/web`) — the merge that made it single
-is done ([app-merge.md](./app-merge.md)). The shell/layout side (docked rail vs.
+is done ([04-app-merge.md](./04-app-merge.md)). The shell/layout side (docked rail vs.
 drawer, keep-mounted constraint) is specced in
-[web-shell.md](./web-shell.md); this doc covers storage, transport, and the
+[web-shell.md](../web-shell.md); this doc covers storage, transport, and the
 message UI.
 
 ## Requirements & constraints
@@ -107,7 +107,7 @@ plain long-lived WebSocket without Durable Objects. That shapes the phases:
   indistinguishable from realtime, needs zero new infrastructure, and ships on
   the current CF hosting. This is the one place the merge left the door open for
   TanStack Query to re-enter surgically (`refetchInterval`) — see the data
-  strategy decision in [app-merge.md](./app-merge.md); a bare `setInterval` +
+  strategy decision in [04-app-merge.md](./04-app-merge.md); a bare `setInterval` +
   `fetcher.load()` may well be enough.
 - **v2 — after Railway.** Swap polling for SSE (preferred: chat clients mostly
   _receive_; no custom server glue, proxy-friendly) or WebSockets (needs a
@@ -134,7 +134,7 @@ headless; no transport/storage opinions):
 - **Stable keys via `getItemKey` with message ids** — index keys break
   prepending. The autoincrement `id` serves.
 
-Shell integration per [web-shell.md](./web-shell.md): docked ~340px rail ≥ `lg`,
+Shell integration per [web-shell.md](../web-shell.md): docked ~340px rail ≥ `lg`,
 drawer overlay below; the chat component stays **always mounted** (draft text,
 scroll position, and — in v2 — the live connection survive dock/undock).
 

--- a/docs/decisions/02-hosting-railway.md
+++ b/docs/decisions/02-hosting-railway.md
@@ -2,7 +2,7 @@
 
 **Status: step 2 done and live; step 3 deferred indefinitely (2026-08-20).**
 Replaces the earlier self-hosted Hetzner idea. Three-step sequence: **app merge
-([app-merge.md](./app-merge.md)) → Railway → Turso→Litestream switch**. Each
+([04-app-merge.md](./04-app-merge.md)) → Railway → Turso→Litestream switch**. Each
 step ships independently:
 
 **Step 3 is no longer treated as required.** Running on Railway against Turso
@@ -60,7 +60,7 @@ into _real_ prod today and imported here later, not double-entered by
 hand). Full detail: `[[project_system_landscape]]` in memory.
 
 What stays on Cloudflare is DNS and R2 — see "What stays on Cloudflare" below.
-The chat feature's realtime transport ([chat-plan.md](./chat-plan.md)) depends
+The chat feature's realtime transport ([01-chat.md](./01-chat.md)) depends
 on this move.
 
 ## Keeping CF (`next.runde.tips`) alive during the transition
@@ -126,7 +126,7 @@ between services anyway.
 ## Architecture: one Node service, one app
 
 Originally planned as a two-fetch-handler dispatcher; the app merge
-([app-merge.md](./app-merge.md)) simplifies this to the boring default —
+([04-app-merge.md](./04-app-merge.md)) simplifies this to the boring default —
 **the standard RR8 Node build of the single merged app**. No dispatcher, no
 path-splitting, no multi-root static serving.
 

--- a/docs/decisions/03-color-scheme.md
+++ b/docs/decisions/03-color-scheme.md
@@ -99,7 +99,7 @@ layout shift and the swap can animate:
 Correct on first paint, no JS, and it keeps tracking the OS in `system` mode
 for free. `ease-out` resolves to the project's custom curve and the default
 150 ms duration sits in the right band for an icon swap — see
-[tokens.md](./tokens.md), which also records that nothing here yet honours
+[tokens.md](../tokens.md), which also records that nothing here yet honours
 `prefers-reduced-motion`.
 
 ## Accessibility

--- a/docs/decisions/04-app-merge.md
+++ b/docs/decisions/04-app-merge.md
@@ -4,7 +4,7 @@
 the React Router 8 app; what was `apps/manager` is now the single `apps/web`
 (`@tipprunde/web`), serving public routes at the root and the manager under
 `/manager` from the one `tipprunde` Worker. Step 1 of the three-step sequence:
-**merge → Railway hosting ([railway-plan.md](./railway-plan.md)) →
+**merge → Railway hosting ([02-hosting-railway.md](./02-hosting-railway.md)) →
 Turso→Litestream switch**.
 
 Delivered as [PR #1](https://github.com/haus23/tipprunde/pull/1) (24 commits,
@@ -49,7 +49,7 @@ routes move under a `/manager` path prefix.
 - **Porting inventory (mechanical, components carry over ~unchanged):** the
   route modules under `apps/web/src/routes` (championship layout + tabelle,
   tipps/{-$slug}, spiele + $nr, zusatzfragen, archiv, login, index
-  dashboard), the shell per [web-shell.md](./web-shell.md) (unchanged spec,
+  dashboard), the shell per [web-shell.md](../web-shell.md) (unchanged spec,
   new host app), server functions → loaders/actions.
 - **Env consolidation:** one `wrangler.jsonc` — web's vars (`TOTP_*`,
   `SESSION_*`, `FROM_EMAIL`, mail secret) join the manager's (`TURSO_*`).
@@ -122,7 +122,7 @@ three-level route structure:
 - **Public layout (pathless).** Web's header shell moves here as-is: logo,
   top nav (Tabelle · Spieler · Spiele), color-scheme menu, user area,
   navigation progress, `max-w-4xl` container. Wraps all public routes
-  including `/login`. The future chat rail ([web-shell.md](./web-shell.md))
+  including `/login`. The future chat rail ([web-shell.md](../web-shell.md))
   attaches to _this_ shell only.
 - **Manager layout (`/manager`).** Everything the manager's `root.tsx` does
   today _except_ the document: `ShellProvider`, sidebar + mobile nav,
@@ -264,6 +264,6 @@ name. It belongs with the build repoint in D3.
   becomes a local file in step 3). Decision is cheap to reverse: Query
   re-enters surgically if a specific route measurably needs client caching —
   at the latest with chat v1's `refetchInterval` polling
-  ([chat-plan.md](./chat-plan.md)).
+  ([01-chat.md](./01-chat.md)).
 - **`packages/ui` stays a package.** Folding it app-local mid-port is churn
   for cosmetic gain; revisit only if the indirection ever annoys.

--- a/docs/decisions/05-championship-scope.md
+++ b/docs/decisions/05-championship-scope.md
@@ -1,7 +1,7 @@
-# Championship Scope — Public Routing Plan
+# Championship Scope — Public Routing
 
 **Status: steps 1-9 done (2026-08-18).** Supersedes the routing parts of
-[archiv.md](./archiv.md); that doc's data design (materialized ranking
+[archiv.md](../archiv.md); that doc's data design (materialized ranking
 columns) is unaffected.
 
 ## The problem
@@ -176,7 +176,7 @@ Consequences:
 
 The switcher lives on the season title, not in the app header — the header has
 no room to spare next to the planned docked chat panel
-(see [web-shell.md](./web-shell.md)).
+(see [web-shell.md](../web-shell.md)).
 
 **No width guard needed on the title.** Names follow exactly two shapes:
 `{Hin,Rück}runde JJJJ/JJ` (max 18 chars, e.g. "Rückrunde 2021/22") or
@@ -195,7 +195,7 @@ rather than popovers or modals. Three reasons:
 1. **The chat makes linkability load-bearing.** Zusatzfragen are asked about
    verbally near the end of a round, precisely because they can still move the
    final ranking — and an in-app chat is planned
-   ([chat-plan.md](./chat-plan.md)). "It's here: …" is an answer in chat; modal
+   ([01-chat.md](./01-chat.md)). "It's here: …" is an answer in chat; modal
    content is not linkable, bookmarkable, or titled.
 2. **The missing ruleset was the legacy app's known shortcoming.** Burying it
    in a modal would partly re-create the problem being fixed.
@@ -239,7 +239,7 @@ Mechanical, but touches many files:
 ## Timing
 
 The app is **not live** — only `next.runde.tips`; real production is still the
-legacy stack (see [railway-plan.md](./railway-plan.md)). URL churn therefore
+legacy stack (see [02-hosting-railway.md](./02-hosting-railway.md)). URL churn therefore
 costs nothing today. After the cutover this becomes a real migration with real
 URLs to preserve. **This is the cheapest moment for this change.**
 

--- a/docs/decisions/06-verlauf-bump-chart.md
+++ b/docs/decisions/06-verlauf-bump-chart.md
@@ -1,4 +1,4 @@
-# Punkteverlauf — Bump Chart Plan
+# Punkteverlauf — Bump Chart
 
 **Status: iteration 1 built (2026-08-19).** One chart, one form — deliberately.
 Earlier attempts existed in two now-retired codebases (a TanStack Start app
@@ -215,13 +215,13 @@ only?" question: it is available in both by construction.
 
 `:playerSlug?` mirrors `/tipps/:playerSlug?` and makes a specific player's run
 linkable ("schau dir an, wie ich ab Spiel 30 abgestürzt bin") — the same
-argument `championship-scope-plan.md` makes for keeping secondary content
+argument `05-championship-scope.md` makes for keeping secondary content
 addressable rather than modal, with the planned chat in mind.
 
 Focus resolution reuses `resolvePlayer()`: explicit slug → logged-in user →
 rank 1.
 
-**No new header entry** — that constraint from `championship-scope-plan.md`
+**No new header entry** — that constraint from `05-championship-scope.md`
 stands. Entry point is a switcher on the Tabelle view, the same shape the old
 app had:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ The app runs as a **single Node service on Railway** (`tipprunde`), serving the
 custom server in `apps/web/server/app.ts`. The Cloudflare Workers deployment it
 used to have is gone — `@cloudflare/vite-plugin` and `wrangler.jsonc` were
 removed with the Node build target, so `main` can no longer produce a Worker at
-all. Background and the steps that got here: [railway-plan.md](./railway-plan.md).
+all. Background and the steps that got here: [02-hosting-railway.md](./decisions/02-hosting-railway.md).
 
 ## Railway service
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,14 +1,41 @@
 # Deployment
 
+The app runs as a **single Node service on Railway** (`tipprunde`), serving the
+custom server in `apps/web/server/app.ts`. The Cloudflare Workers deployment it
+used to have is gone — `@cloudflare/vite-plugin` and `wrangler.jsonc` were
+removed with the Node build target, so `main` can no longer produce a Worker at
+all. Background and the steps that got here: [railway-plan.md](./railway-plan.md).
+
+## Railway service
+
+| Setting        | Value                     | Why                                                |
+| -------------- | ------------------------- | -------------------------------------------------- |
+| Root Directory | repo root                 | pnpm workspace resolution needs it, not `apps/web` |
+| Build Command  | `pnpm --filter web build` |                                                    |
+| Start Command  | `pnpm --filter web start` |                                                    |
+
+Railway injects its own `PORT`; `server/app.ts` uses whatever it is given, so a
+manually set `PORT` variable in the dashboard is dead weight rather than a bug
+if you find the container listening elsewhere than you expected.
+
+### Environments
+
+- **production** — deploys from `main`.
+- **pr-base** — the template PR Environments are cloned from. Its variables
+  point at the dev database, so a preview never touches the real one.
+- **tipprunde-pr-N** — created per pull request, deleted when it closes.
+
+PR Environments copy the base environment's variables at creation. If a base
+variable changes while a PR is open, that PR keeps the old value until it is
+synced — worth remembering when rotating a token.
+
 ## Environment variables
 
-One app (`apps/web`), one set of variables. Locally they live in
-`apps/web/.env`; on Cloudflare the secrets are set on the Worker and the
-plain values come from `vars` in `wrangler.jsonc`. Both lists are mirrored in
-`wrangler.jsonc` (`secrets.required` + `vars`), so `wrangler deploy` fails
-loudly and by name when a secret is missing.
+One app, one set of variables. Locally they live in `apps/web/.env`; on Railway
+they are set per environment in the dashboard. Railway makes no secret/var
+distinction, but the split still matters for where a value may be written down:
 
-### Secrets (never in `wrangler.jsonc`)
+### Secrets — never in the repo
 
 | Variable             | Description                                    |
 | -------------------- | ---------------------------------------------- |
@@ -18,7 +45,7 @@ loudly and by name when a secret is missing.
 | `APP_SECRET`         | HMAC key for TOTP login codes                  |
 | `RESEND_API_KEY`     | Resend API key for sending the login code mail |
 
-### Vars (in `wrangler.jsonc`)
+### Plain values
 
 | Variable                    | Default            | Description                        |
 | --------------------------- | ------------------ | ---------------------------------- |
@@ -28,9 +55,9 @@ loudly and by name when a secret is missing.
 | `SESSION_DURATION_REMEMBER` | `2592000`          | Lifetime with "angemeldet bleiben" |
 | `FROM_EMAIL`                | `hallo@runde.tips` | Sender of the login code mail      |
 
-`wrangler deploy` replaces the dashboard's _vars_ with the ones from
-`wrangler.jsonc`, but leaves _secrets_ alone — so secrets are set once per
-Worker with `wrangler secret put` (or in the dashboard) and survive deploys.
+The login flow needs all of them, not just the database pair: without
+`RESEND_API_KEY` or `APP_SECRET` nobody can get a code, and the failure looks
+like a mail problem rather than a missing variable.
 
 ## First-deploy bootstrap
 
@@ -45,8 +72,7 @@ INSERT INTO users (name, slug, email, role)
 VALUES ('Your Name', 'your-slug', 'your@email.com', 'admin');
 ```
 
-Via Drizzle Studio (`bun run db:studio` in the db package) or any
-SQLite/libSQL client. After that, log in at `/login`.
+Via Drizzle Studio or any SQLite/libSQL client. After that, log in at `/login`.
 
 All further user management happens inside the manager under
 **Stammdaten → Spieler**.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,7 +20,9 @@ if you find the container listening elsewhere than you expected.
 
 ### Environments
 
-- **production** — deploys from `main`.
+- **production** — deploys from `main`, and serves **https://next.runde.tips**.
+  The apex `runde.tips` still belongs to the legacy stack and joins this
+  service at go-live, after which `next.` is dropped.
 - **pr-base** — the template PR Environments are cloned from. Its variables
   point at the dev database, so a preview never touches the real one.
 - **tipprunde-pr-N** — created per pull request, deleted when it closes.

--- a/docs/railway-plan.md
+++ b/docs/railway-plan.md
@@ -68,11 +68,12 @@ on this move.
 > **Played out as written, and now over (2026-08-20).** The CF build path was
 > removed with the Node build target, so `main` cannot produce a Worker any
 > more, and the Worker sat frozen on its last pre-merge deployment. Its one
-> hostname has since been repointed: **`next.runde.tips` now serves the Railway
-> production deployment**, which leaves the Worker without a name and with
-> nothing to fall back to. The fallback this section was designed around is
-> therefore gone — deliberately, since Railway has been carrying the app for
-> months. Kept as the record of how it went.
+> custom domain has since been repointed: **`next.runde.tips` now serves the
+> Railway production deployment.** The Worker itself is still reachable on its
+> `*.workers.dev` URL, so the last pre-merge build has not disappeared — it
+> simply is not on a name anyone uses, and its code is months stale. The
+> fallback this section was designed around is over as a plan, deliberately,
+> since Railway has been carrying the app all along. Kept as the record.
 
 CF's Git integration (Workers Builds) auto-builds and deploys on every push
 to the **production branch** (`main`) — there is no manual `wrangler deploy`
@@ -194,9 +195,10 @@ serving is most of what the custom server exists to do.
 ## What stays on Cloudflare
 
 DNS (free plan) and R2 (the backup target, only relevant if step 3 is ever
-taken). Nothing is served from Cloudflare any more: `next.runde.tips` points at
-Railway, and the `tipprunde` Worker has no hostname left. Turso holds both the
-dev and the "prod" database on the free tier.
+taken). No custom domain resolves to Cloudflare any more — `next.runde.tips`
+points at Railway — though the `tipprunde` Worker still answers on its
+`*.workers.dev` URL with its last pre-merge build. Turso holds both the dev and
+the "prod" database on the free tier.
 
 ## Open questions
 

--- a/docs/railway-plan.md
+++ b/docs/railway-plan.md
@@ -50,26 +50,29 @@ today. Real prod is a separate, older stack that's held real data since
 - `runde.tips` (the real apex domain) — CF Worker, **TanStack Router** SPA,
   reads from `unterbau`.
 
-This repo's Worker (`tipprunde`) only serves **`next.runde.tips`** today —
-it has never had the apex domain. **Step 9's "DNS cutover" below is not a
-routine infra swap: it's the go-live moment for the whole rebuild**,
+This repo has never had the apex domain — **`next.runde.tips`** is its
+hostname, and as of 2026-08-20 that name points at the **Railway production
+deployment**, not at the CF Worker any more. **Step 9's "DNS cutover" below is
+not a routine infra swap: it's the go-live moment for the whole rebuild**,
 retiring all three services above at once, once this app holds the full
 2002–now history (including the currently-running Hinrunde 2026/27, entered
 into _real_ prod today and imported here later, not double-entered by
 hand). Full detail: `[[project_system_landscape]]` in memory.
 
-Current CF Workers hosting (see [deployment.md](./deployment.md)) stays for
-dev/`next.runde.tips` and runs in parallel during the transition. The chat
-feature's transport upgrade ([chat-plan.md](./chat-plan.md) v2) depends on
-this move.
+What stays on Cloudflare is DNS and R2 — see "What stays on Cloudflare" below.
+The chat feature's realtime transport ([chat-plan.md](./chat-plan.md)) depends
+on this move.
 
 ## Keeping CF (`next.runde.tips`) alive during the transition
 
-> **This already played out as written.** The CF build path was removed with
-> the Node build target, so `main` cannot produce a Worker any more and
-> `next.runde.tips` has been frozen on its last pre-merge deployment ever
-> since. It still answers, with stale code — do not read it as a check of
-> anything current. The section is kept as the record of how that came about.
+> **Played out as written, and now over (2026-08-20).** The CF build path was
+> removed with the Node build target, so `main` cannot produce a Worker any
+> more, and the Worker sat frozen on its last pre-merge deployment. Its one
+> hostname has since been repointed: **`next.runde.tips` now serves the Railway
+> production deployment**, which leaves the Worker without a name and with
+> nothing to fall back to. The fallback this section was designed around is
+> therefore gone — deliberately, since Railway has been carrying the app for
+> months. Kept as the record of how it went.
 
 CF's Git integration (Workers Builds) auto-builds and deploys on every push
 to the **production branch** (`main`) — there is no manual `wrangler deploy`
@@ -92,12 +95,11 @@ automatically, frozen, no action required. Disconnecting the Git integration
 at that point is optional cleanup (stops CF flagging every later, unrelated
 push as a failed build) — do it then, not before.
 
-**`next.runde.tips` retirement (decided 2026-08-12):** stays alive as a
-fallback through **both** step 2 and step 3. Moving the real `runde.tips`
-DNS to Railway (step 9) is unrelated to this Worker, so `next.runde.tips`
-keeps working unmodified as a rollback reference the whole time. Delete the
-domain only once step 3 (local SQLite + Litestream) is proven — holding it
-beyond that point stops making sense once the DB layer is settled too.
+~~**`next.runde.tips` retirement (decided 2026-08-12):** stays alive as a
+fallback through **both** step 2 and step 3.~~ **Superseded 2026-08-20:** the
+hostname was handed to Railway instead of being held back as a rollback
+reference. Step 3 is deferred anyway, so waiting for it before releasing the
+name had stopped meaning anything.
 
 ## Cost target & breakdown
 
@@ -180,9 +182,10 @@ serving is most of what the custom server exists to do.
    is on a Custom Domain/Route pointing at the legacy stack today (see "What
    this plan actually cuts over" above), not at anything of ours — moving it
    to Railway (CNAME, proxied or DNS-only) is a first-time assignment for
-   this app, not a swap away from `tipprunde`. `next.runde.tips` (CF
-   Workers) is a separate hostname, untouched, and can stay up in parallel —
-   no big-bang switch for it. **`hinterhof.runde.tips` and
+   this app, not a swap away from `tipprunde`. `next.runde.tips` is a separate
+   hostname already pointing at this Railway deployment, so the apex move only
+   adds a second name to the same service — and `next.` can be dropped once it
+   has. **`hinterhof.runde.tips` and
    `unterbau.runde.tips` are retired outright at this point (decided
    2026-08-12)** — this app's `/manager` supersedes hinterhof's admin
    function, and no Firestore left to shield means unterbau has nothing left
@@ -190,10 +193,10 @@ serving is most of what the custom server exists to do.
 
 ## What stays on Cloudflare
 
-DNS (free plan), R2 (backup target), and — as a fallback until step 3 is
-proven, see "Keeping CF alive during the transition" above — `next.runde.tips`
-on the `tipprunde` Worker. Turso remains for the dev DB only, on the free
-tier, and can retire once dev also runs against local files if ever desired.
+DNS (free plan) and R2 (the backup target, only relevant if step 3 is ever
+taken). Nothing is served from Cloudflare any more: `next.runde.tips` points at
+Railway, and the `tipprunde` Worker has no hostname left. Turso holds both the
+dev and the "prod" database on the free tier.
 
 ## Open questions
 
@@ -220,6 +223,6 @@ Still genuinely open:
 
 - When to cut `runde.tips` DNS over to Railway: after the 50-championships
   backlog entry, together with chat v1 → v2, or earlier as a standalone
-  infra change. (`next.runde.tips`'s own retirement, and the fate of
-  `hinterhof`/`unterbau`, are both decided — see above; this is only about
-  the timing of the production hostname move.)
+  infra change. (The fate of `hinterhof`/`unterbau` is decided — see above;
+  this is only about the timing of the production hostname move. `next.` then
+  becomes redundant and goes away with it.)

--- a/docs/railway-plan.md
+++ b/docs/railway-plan.md
@@ -1,15 +1,21 @@
 # Production Hosting — Railway Plan
 
-**Status: step 2 core deploy proven live (2026-08-13).** Replaces the earlier
-self-hosted Hetzner idea. Step 2 of the three-step sequence: **app merge
+**Status: step 2 done and live; step 3 deferred indefinitely (2026-08-20).**
+Replaces the earlier self-hosted Hetzner idea. Three-step sequence: **app merge
 ([app-merge.md](./app-merge.md)) → Railway → Turso→Litestream switch**. Each
 step ships independently:
 
-**Railway project exists (2026-08-13):** `tipprunde` service, branch
-`railway-node-build`, at `https://tipprunde.up.railway.app` — still against
-the **dev** Turso branch for now, deliberately (see "Data cutover" problem
-below; don't point this at the real backlog-entry DB until the service
-itself is proven over time). Verified end-to-end against the live URL:
+**Step 3 is no longer treated as required.** Running on Railway against Turso
+performs very well, so the move to a local SQLite file plus Litestream buys
+little today. The one thing that would force it is **outgrowing Turso's free
+tier**. Everything below about step 3 stays as a worked-out plan for that case,
+not as pending work.
+
+**Railway project (2026-08-13):** `tipprunde` service at
+`https://tipprunde.up.railway.app`. It now runs against this rebuild's own
+"prod" Turso database — switched over deliberately, with a backup taken first,
+once the service had proven itself; the caution below about staying on the dev
+branch describes the initial state, not the current one. Verified end-to-end against the live URL:
 SSR render, 404 handling, the `/manager` → `/login` middleware redirect,
 and immutable-cached gzip assets — same checks as the local build, all
 correct. Root Directory is the repo root (not `apps/web` — required for
@@ -23,12 +29,13 @@ expected.
 1. ~~**App merge** — no infra change, ships on current CF hosting.~~
    **Done 2026-08-09**, live on the single `tipprunde` Worker, serving only
    `next.runde.tips` (see below — this did **not** touch real prod).
-2. **Railway move** ← in progress. No data-layer change: the merged app runs
+2. ~~**Railway move**~~ — **done.** No data-layer change: the merged app runs
    on Railway **still against Turso** (`drizzle-orm/libsql/web` works from
-   anywhere). Core deploy (problems 1–2) proven live, see above; problems
-   6–9 (restore test, DNS cutover) still ahead.
-3. **Turso → local SQLite + Litestream** — pure DB-layer change on stable
-   hosting: volume, driver swap, Litestream, migration-workflow change.
+   anywhere). The DNS cutover (problem 9) is a separate matter — it is the
+   rebuild's go-live, not part of the hosting move.
+3. **Turso → local SQLite + Litestream** — **deferred**, see above. Pure
+   DB-layer change on stable hosting: volume, driver swap, Litestream,
+   migration-workflow change.
 
 ## What this plan actually cuts over — read this before "DNS cutover" below
 
@@ -57,6 +64,12 @@ feature's transport upgrade ([chat-plan.md](./chat-plan.md) v2) depends on
 this move.
 
 ## Keeping CF (`next.runde.tips`) alive during the transition
+
+> **This already played out as written.** The CF build path was removed with
+> the Node build target, so `main` cannot produce a Worker any more and
+> `next.runde.tips` has been frozen on its last pre-merge deployment ever
+> since. It still answers, with stale code — do not read it as a check of
+> anything current. The section is kept as the record of how that came about.
 
 CF's Git integration (Workers Builds) auto-builds and deploys on every push
 to the **production branch** (`main`) — there is no manual `wrangler deploy`

--- a/docs/web-shell.md
+++ b/docs/web-shell.md
@@ -8,7 +8,7 @@ panel's docked/drawer behaviour. Breakpoint _values_ live in
 [tokens.md](./tokens.md); this doc describes how the shell uses them.
 
 Built today: header, nav, color-scheme toggle, user area. The chat panel is
-planned — see [chat-plan.md](./chat-plan.md). View Transitions were considered and
+planned — see [01-chat.md](./decisions/01-chat.md). View Transitions were considered and
 postponed — see "View Transitions — postponed" below.
 
 ## Header contents (widest state)
@@ -27,7 +27,7 @@ Two things deliberately do **not** get their own top-level header slot:
 
 1. **Scheme control is one button.** A single sun/moon control toggles between light
    and dark; "system" is reached implicitly, without occupying a slot of its own — see
-   [color-scheme.md](./color-scheme.md). Two always-visible theming buttons, or a
+   [03-color-scheme.md](./decisions/03-color-scheme.md). Two always-visible theming buttons, or a
    three-item menu, would spend scarce header width on a rarely-touched setting.
 2. **Manager link + Logout live inside the user menu.** Manager is role-gated (only
    managers/admins see it) and rarely clicked; Logout is by definition an account

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "0.28.0",
+  "version": "1.0.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/packages/domain/src/progression.ts
+++ b/packages/domain/src/progression.ts
@@ -43,7 +43,7 @@ export type PlayerProgression = {
  *
  * Returns one entry per input player, in input order.
  *
- * See docs/verlauf-plan.md.
+ * See docs/decisions/06-verlauf-bump-chart.md.
  */
 export function calcProgression({
   players,


### PR DESCRIPTION
Groundwork for the 1.0.0 release.

## The release section — the actual point

With a 1.x version the "`--minor` means patch" special case for major version 0 disappears, so the documented commands would have produced **1.1.0 for the first bugfix**. [CLAUDE.md](../blob/chore/docs-for-1.0/CLAUDE.md#release-from-repo-root) now spells out patch/minor/major, adds the `-r` form for the one-off jump to 1.0.0, records the release-before-merge order, and states what "breaking" means for an app with no public API: **public URLs, DB schema, session format**.

## docs/deployment.md — rewritten

It still described the Cloudflare Workers model, built around a `wrangler.jsonc` that no longer exists in the repo. Replaced with the Railway service: settings, the production/pr-base environments, and the variables per environment.

## Smaller corrections

- `apps/web/CLAUDE.md` listed **Cloudflare Workers** in the stack.
- `railway-plan.md` read as if the Railway move were still ahead, and step 3 (Litestream) as pending — it is deferred unless Turso's free tier runs out.
- `chat-plan.md` phased storage and transport as "now (CF Workers)" vs "later (Railway)", which would have sent whoever builds chat down the wrong branch.

`app-merge.md` keeps its Cloudflare references on purpose — it is the history of the merge, and that is what was true then.

Docs only, no code. `pnpm --filter web typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)