### PR TITLE
feat: Legacy-Import-Feature (Turnier 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.2.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.1.0...v1.2.0)
+
+### 🚀 Enhancements
+
+- **web:** Switch from the HTTP-only libsql client to the Node client ([55c2a76](https://github.com/haus23/tipprunde/commit/55c2a76))
+- **web:** Add the legacy-import tool (admin-only, temporary) ([ed270f3](https://github.com/haus23/tipprunde/commit/ed270f3))
+- **web:** Add a sidebar link for the legacy-import tool ([60aa7ce](https://github.com/haus23/tipprunde/commit/60aa7ce))
+
 ## v1.1.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.0.0...v1.1.0)

--- a/apps/web/app/lib/db.server.ts
+++ b/apps/web/app/lib/db.server.ts
@@ -1,5 +1,5 @@
 import { relations } from "@tipprunde/db/relations";
-import { drizzle } from "drizzle-orm/libsql/web";
+import { drizzle } from "drizzle-orm/libsql";
 
 export const db = drizzle({
   connection: {

--- a/apps/web/app/lib/import.server.ts
+++ b/apps/web/app/lib/import.server.ts
@@ -1,0 +1,245 @@
+import {
+  leagues as leaguesTable,
+  matches as matchesTable,
+  players as playersTable,
+  rounds as roundsTable,
+  teams as teamsTable,
+  tips as tipsTable,
+} from "@tipprunde/db/schema";
+import { calcTipPoints, type TipRuleId } from "@tipprunde/domain/scoring";
+import { eq } from "drizzle-orm";
+import { createInsertSchema } from "drizzle-orm/valibot";
+import * as v from "valibot";
+
+import type { Championship } from "#/lib/context.ts";
+
+import { db } from "./db.server";
+import { updateRanking } from "./ranking.server";
+
+// --- Schema ---
+//
+// Mirrors the legacy-import JSON built outside the repo (see
+// project_legacy_import.md) — one championship at a time, master-data
+// additions bundled with the championship-scoped rounds/matches/tips.
+// References are stable IDs/numbers throughout, never raw DB foreign keys:
+// `roundNr` instead of `roundId`, `matchNr` instead of `matchId`,
+// `playerSlug` instead of `userId` — none of those rows exist yet when this
+// JSON was written, only once the import actually runs.
+
+const trimmedNonEmpty = (schema: v.GenericSchema<string>) => v.pipe(schema, v.trim(), v.nonEmpty());
+
+const newTeamSchema = createInsertSchema(teamsTable, {
+  id: trimmedNonEmpty,
+  name: trimmedNonEmpty,
+  shortName: trimmedNonEmpty,
+});
+
+const newLeagueSchema = createInsertSchema(leaguesTable, {
+  id: trimmedNonEmpty,
+  name: trimmedNonEmpty,
+  shortName: trimmedNonEmpty,
+});
+
+const matchSchema = v.object({
+  nr: v.number(),
+  roundNr: v.number(),
+  date: v.nullable(v.string()),
+  leagueId: v.string(),
+  hometeamId: v.string(),
+  awayteamId: v.string(),
+  result: v.nullable(v.string()),
+  lowestSumBonus: v.nullable(v.boolean()),
+});
+
+const tipSchema = v.object({
+  matchNr: v.number(),
+  playerSlug: v.string(),
+  tip: v.string(),
+  joker: v.nullable(v.boolean()),
+  extraJoker: v.nullable(v.boolean()),
+  points: v.nullable(v.number()),
+});
+
+export const importSchema = v.object({
+  championshipSlug: v.string(),
+  newTeams: v.array(newTeamSchema),
+  newLeagues: v.array(newLeagueSchema),
+  players: v.array(v.string()),
+  matches: v.array(matchSchema),
+  tips: v.array(tipSchema),
+});
+
+export type ImportPayload = v.InferOutput<typeof importSchema>;
+
+export type ImportSummary = {
+  teams: number;
+  leagues: number;
+  players: number;
+  matches: number;
+  tips: number;
+};
+
+// --- Import ---
+
+/**
+ * Writes one championship's legacy-import JSON. Upserts throughout — safe to
+ * run the same JSON again after a correction. Points are never taken from
+ * the JSON; always recomputed via calcTipPoints, same as every other write
+ * path in the app.
+ *
+ * Everything happens in one transaction: any failure rolls back completely,
+ * never a partial import.
+ */
+export async function importLegacyData(
+  championship: Championship,
+  payload: ImportPayload,
+): Promise<ImportSummary> {
+  if (payload.championshipSlug !== championship.slug) {
+    throw new Error(
+      `JSON ist für Championship "${payload.championshipSlug}", diese Seite ist "${championship.slug}".`,
+    );
+  }
+
+  const ruleset = await db.query.rulesets.findFirst({
+    where: { id: championship.rulesetId },
+    columns: { tipRuleId: true },
+  });
+  if (!ruleset) throw new Error("Regelwerk der Championship nicht gefunden.");
+  const tipRuleId = ruleset.tipRuleId as TipRuleId;
+
+  const summary: ImportSummary = { teams: 0, leagues: 0, players: 0, matches: 0, tips: 0 };
+
+  await db.transaction(async (tx) => {
+    for (const team of payload.newTeams) {
+      await tx
+        .insert(teamsTable)
+        .values(team)
+        .onConflictDoUpdate({
+          target: teamsTable.id,
+          set: { name: team.name, shortName: team.shortName },
+        });
+    }
+    summary.teams = payload.newTeams.length;
+
+    for (const league of payload.newLeagues) {
+      await tx
+        .insert(leaguesTable)
+        .values(league)
+        .onConflictDoUpdate({
+          target: leaguesTable.id,
+          set: { name: league.name, shortName: league.shortName },
+        });
+    }
+    summary.leagues = payload.newLeagues.length;
+
+    const foundUsers = await tx.query.users.findMany({
+      where: { slug: { in: payload.players } },
+      columns: { id: true, slug: true },
+    });
+    const userIdBySlug = new Map(foundUsers.map((u) => [u.slug, u.id]));
+    for (const slug of payload.players) {
+      const userId = userIdBySlug.get(slug);
+      if (!userId) throw new Error(`Unbekannter Spieler-Slug: "${slug}"`);
+      await tx
+        .insert(playersTable)
+        .values({ championshipId: championship.id, userId })
+        .onConflictDoNothing();
+    }
+    summary.players = payload.players.length;
+
+    // Rounds: one per distinct roundNr seen in matches — find or create,
+    // caching id + isDoubleRound (needed for scoring below) per nr.
+    const roundNrs = [...new Set(payload.matches.map((m) => m.roundNr))].sort((a, b) => a - b);
+    const roundByNr = new Map<number, { id: number; isDoubleRound: boolean | null }>();
+    for (const nr of roundNrs) {
+      const existing = await tx.query.rounds.findFirst({
+        where: { championshipId: championship.id, nr },
+        columns: { id: true, isDoubleRound: true },
+      });
+      if (existing) {
+        roundByNr.set(nr, existing);
+        continue;
+      }
+      const [inserted] = await tx
+        .insert(roundsTable)
+        .values({ championshipId: championship.id, nr })
+        .returning({ id: roundsTable.id });
+      roundByNr.set(nr, { id: inserted!.id, isDoubleRound: null });
+    }
+
+    // Matches have no unique constraint to upsert against (nr is only
+    // conventionally unique per championship, not enforced) — find, then
+    // insert or update.
+    const matchIdByNr = new Map<number, number>();
+    for (const match of payload.matches) {
+      const round = roundByNr.get(match.roundNr);
+      if (!round) throw new Error(`Runde ${match.roundNr} nicht gefunden (Spiel ${match.nr}).`);
+
+      const values = {
+        roundId: round.id,
+        nr: match.nr,
+        date: match.date,
+        leagueId: match.leagueId,
+        hometeamId: match.hometeamId,
+        awayteamId: match.awayteamId,
+        result: match.result,
+        lowestSumBonus: match.lowestSumBonus,
+      };
+
+      const existing = await tx.query.matches.findFirst({
+        where: { roundId: round.id, nr: match.nr },
+        columns: { id: true },
+      });
+      if (existing) {
+        await tx.update(matchesTable).set(values).where(eq(matchesTable.id, existing.id));
+        matchIdByNr.set(match.nr, existing.id);
+      } else {
+        const [inserted] = await tx
+          .insert(matchesTable)
+          .values(values)
+          .returning({ id: matchesTable.id });
+        matchIdByNr.set(match.nr, inserted!.id);
+      }
+    }
+    summary.matches = payload.matches.length;
+
+    const matchByNr = new Map(payload.matches.map((m) => [m.nr, m]));
+    for (const tip of payload.tips) {
+      const matchId = matchIdByNr.get(tip.matchNr);
+      if (!matchId) throw new Error(`Unbekannte Spiel-Nr in Tipp: ${tip.matchNr}.`);
+      const userId = userIdBySlug.get(tip.playerSlug);
+      if (!userId) throw new Error(`Unbekannter Spieler-Slug in Tipp: "${tip.playerSlug}".`);
+
+      const match = matchByNr.get(tip.matchNr)!;
+      const isDoubleRound = roundByNr.get(match.roundNr)?.isDoubleRound ?? null;
+      const points = calcTipPoints(
+        tip.tip,
+        match.result,
+        tipRuleId,
+        isDoubleRound,
+        tip.joker,
+        tip.extraJoker,
+      );
+
+      await tx
+        .insert(tipsTable)
+        .values({
+          matchId,
+          userId,
+          tip: tip.tip,
+          points,
+          joker: tip.joker,
+          extraJoker: tip.extraJoker,
+        })
+        .onConflictDoUpdate({
+          target: [tipsTable.matchId, tipsTable.userId],
+          set: { tip: tip.tip, points, joker: tip.joker, extraJoker: tip.extraJoker },
+        });
+    }
+    summary.tips = payload.tips.length;
+  });
+
+  await updateRanking(championship.id);
+
+  return summary;
+}

--- a/apps/web/app/lib/session.server.ts
+++ b/apps/web/app/lib/session.server.ts
@@ -56,6 +56,10 @@ export function isManager(user: User | null): boolean {
   return user?.role === "manager" || user?.role === "admin";
 }
 
+export function isAdmin(user: User | null): boolean {
+  return user?.role === "admin";
+}
+
 function generateSessionId(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -70,6 +70,9 @@ export default [
       route("ergebnisse/:nr?", "routes/manager/championship/ergebnisse.tsx"),
       route("spiele/:nr?", "routes/manager/championship/spiele.tsx"),
       route("tipps/:playerSlug?", "routes/manager/championship/tipps.tsx"),
+      // Temporary: the legacy-import tool, removed once the last historical
+      // tournament is imported. Admin-only, see import.tsx's own gate.
+      route("import", "routes/manager/championship/import.tsx"),
       route("zusatzfragen", "routes/manager/championship/zusatzfragen.tsx"),
     ]),
     route("shell", "routes/_resources/manager-shell.tsx"),

--- a/apps/web/app/routes/manager/_layout.tsx
+++ b/apps/web/app/routes/manager/_layout.tsx
@@ -12,7 +12,7 @@ import {
 } from "#/lib/championship.server.ts";
 import { championshipContext, userContext } from "#/lib/context.ts";
 import { clearCookieHeader, cookieHeader, getCookie } from "#/lib/cookies.server.ts";
-import { isManager } from "#/lib/session.server.ts";
+import { isAdmin, isManager } from "#/lib/session.server.ts";
 import { usePageTitle } from "#/lib/utils.ts";
 
 import type { Route } from "./+types/_layout";
@@ -55,7 +55,8 @@ const championshipMiddleware: Route.MiddlewareFunction = async ({ request, conte
 export const middleware: Route.MiddlewareFunction[] = [authMiddleware, championshipMiddleware];
 
 export function loader({ context, request }: Route.LoaderArgs) {
-  if (!isManager(context.get(userContext))) {
+  const user = context.get(userContext);
+  if (!isManager(user)) {
     throw data("Kein Zugriff auf den Manager.", { status: 403 });
   }
 
@@ -66,6 +67,7 @@ export function loader({ context, request }: Route.LoaderArgs) {
     name: championship?.name,
     sidebarCollapsed,
     championships: getChampionships(),
+    isAdmin: isAdmin(user),
   };
 }
 
@@ -78,7 +80,7 @@ export default function ManagerLayout({ loaderData }: Route.ComponentProps) {
 }
 
 function Shell({ loaderData }: { loaderData: Route.ComponentProps["loaderData"] }) {
-  const { slug, name, championships } = loaderData;
+  const { slug, name, championships, isAdmin } = loaderData;
   const pageTitle = usePageTitle();
   const { isSidebarCollapsed, toggleSidebar, toggleMobileMenu } = useShell();
 
@@ -89,8 +91,8 @@ function Shell({ loaderData }: { loaderData: Route.ComponentProps["loaderData"] 
         isSidebarCollapsed ? "md:grid-cols-[56px_1fr]" : "md:grid-cols-[208px_1fr]",
       )}
     >
-      <Sidebar slug={slug} />
-      <MobileNav slug={slug} />
+      <Sidebar slug={slug} isAdmin={isAdmin} />
+      <MobileNav slug={slug} isAdmin={isAdmin} />
       <header className="border-subtle bg-surface-raised flex items-center gap-1 border-b px-4">
         <Button
           intent="ghost"

--- a/apps/web/app/routes/manager/_mobile-nav.tsx
+++ b/apps/web/app/routes/manager/_mobile-nav.tsx
@@ -8,10 +8,11 @@ import { SidebarNav } from "./_sidebar.tsx";
 
 type MobileNavProps = {
   slug: string | undefined;
+  isAdmin: boolean;
 };
 
 /** Mobile-only drawer (< md). Slides in from the left, closes on navigation. */
-export function MobileNav({ slug }: MobileNavProps) {
+export function MobileNav({ slug, isAdmin }: MobileNavProps) {
   const { isMobileMenuOpen, closeMobileMenu } = useShell();
   const { pathname } = useLocation();
 
@@ -43,7 +44,12 @@ export function MobileNav({ slug }: MobileNavProps) {
             </Link>
           </div>
 
-          <SidebarNav slug={slug} collapsed={false} onNavigate={closeMobileMenu} />
+          <SidebarNav
+            slug={slug}
+            isAdmin={isAdmin}
+            collapsed={false}
+            onNavigate={closeMobileMenu}
+          />
         </Dialog>
       </Modal>
     </ModalOverlay>

--- a/apps/web/app/routes/manager/_sidebar.tsx
+++ b/apps/web/app/routes/manager/_sidebar.tsx
@@ -13,6 +13,7 @@ import {
   RocketIcon,
   StarIcon,
   TrophyIcon,
+  UploadIcon,
   UsersIcon,
 } from "lucide-react";
 import { Focusable, Tooltip, TooltipTrigger } from "react-aria-components";
@@ -71,12 +72,13 @@ function NavItem({ to, end, icon: Icon, label, collapsed, onNavigate }: NavItemP
 
 type SidebarNavProps = {
   slug: string | undefined;
+  isAdmin: boolean;
   collapsed: boolean;
   onNavigate?: () => void;
 };
 
 /** Shared nav body for the persistent sidebar (rail) and the mobile drawer. */
-export function SidebarNav({ slug, collapsed, onNavigate }: SidebarNavProps) {
+export function SidebarNav({ slug, isAdmin, collapsed, onNavigate }: SidebarNavProps) {
   const logoutButton = (
     <Button
       type="submit"
@@ -137,6 +139,15 @@ export function SidebarNav({ slug, collapsed, onNavigate }: SidebarNavProps) {
               collapsed={collapsed}
               onNavigate={onNavigate}
             />
+            {isAdmin && (
+              <NavItem
+                to={`/manager/${slug}/import`}
+                icon={UploadIcon}
+                label="Legacy-Import"
+                collapsed={collapsed}
+                onNavigate={onNavigate}
+              />
+            )}
           </>
         ) : (
           <NavItem
@@ -219,10 +230,11 @@ export function SidebarNav({ slug, collapsed, onNavigate }: SidebarNavProps) {
 
 type SidebarProps = {
   slug: string | undefined;
+  isAdmin: boolean;
 };
 
 /** Persistent sidebar (md+), collapsible between full (208px) and rail (56px). */
-export function Sidebar({ slug }: SidebarProps) {
+export function Sidebar({ slug, isAdmin }: SidebarProps) {
   const { isSidebarCollapsed } = useShell();
 
   return (
@@ -246,7 +258,7 @@ export function Sidebar({ slug }: SidebarProps) {
         </Link>
       </div>
 
-      <SidebarNav slug={slug} collapsed={isSidebarCollapsed} />
+      <SidebarNav slug={slug} isAdmin={isAdmin} collapsed={isSidebarCollapsed} />
     </aside>
   );
 }

--- a/apps/web/app/routes/manager/championship/import.tsx
+++ b/apps/web/app/routes/manager/championship/import.tsx
@@ -1,0 +1,101 @@
+import { Button, Card, CardContent, FieldError, Label, TextArea } from "@tipprunde/ui";
+import { TextField } from "react-aria-components";
+import { data, useFetcher } from "react-router";
+import * as v from "valibot";
+
+import { championshipContext, userContext } from "#/lib/context.ts";
+import { importLegacyData, importSchema, type ImportSummary } from "#/lib/import.server.ts";
+import { isAdmin } from "#/lib/session.server.ts";
+
+import type { Route } from "./+types/import";
+
+export const handle = { title: "Legacy-Import" };
+
+// Temporary tool for the historical-data import — see project_legacy_import.md
+// (outside the repo). Removed once the last tournament from the dump lands.
+
+function issueMessages(issues: readonly v.BaseIssue<unknown>[]): string[] {
+  return issues.map((issue) => {
+    const path = issue.path?.map((p) => String(p.key)).join(".");
+    return path ? `${path}: ${issue.message}` : issue.message;
+  });
+}
+
+export async function loader({ context }: Route.LoaderArgs) {
+  if (!isAdmin(context.get(userContext))) {
+    throw data("Nur für Admins.", { status: 403 });
+  }
+  return null;
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  if (!isAdmin(context.get(userContext))) {
+    throw data("Nur für Admins.", { status: 403 });
+  }
+  const championship = context.get(championshipContext);
+  const formData = await request.formData();
+  const raw = String(formData.get("json") ?? "");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { errors: { json: ["Kein gültiges JSON."] } };
+  }
+
+  const result = v.safeParse(importSchema, parsed);
+  if (!result.success) {
+    return { errors: { json: issueMessages(result.issues) } };
+  }
+
+  try {
+    const summary = await importLegacyData(championship, result.output);
+    return { summary };
+  } catch (err) {
+    return { errors: { json: [err instanceof Error ? err.message : "Unbekannter Fehler."] } };
+  }
+}
+
+export default function Import() {
+  const fetcher = useFetcher<{ errors?: { json: string[] }; summary?: ImportSummary }>();
+  const isPending = fetcher.state !== "idle";
+  const errors = fetcher.data?.errors?.json;
+  const summary = fetcher.data?.summary;
+
+  return (
+    <div className="p-8">
+      <title>Legacy-Import</title>
+      <div className="max-w-2xl">
+        <Card>
+          <CardContent>
+            <fetcher.Form method="post" className="flex flex-col gap-4">
+              <TextField name="json" isRequired className="flex flex-col gap-1.5">
+                <Label>Import-JSON</Label>
+                <TextArea rows={16} className="font-mono text-xs" />
+                <FieldError>{errors?.[0]}</FieldError>
+              </TextField>
+              <Button type="submit" isDisabled={isPending} className="self-start">
+                {isPending ? "Importiere…" : "Import starten"}
+              </Button>
+            </fetcher.Form>
+
+            {errors && errors.length > 1 && (
+              <ul className="text-error mt-4 list-disc pl-5 text-sm">
+                {errors.map((e) => (
+                  <li key={e}>{e}</li>
+                ))}
+              </ul>
+            )}
+
+            {summary && (
+              <p className="text-accent mt-4 text-sm">
+                {summary.teams} Teams · {summary.leagues} Ligen · {summary.players} Spieler ·{" "}
+                {summary.matches} Spiele · {summary.tips} Tipps importiert.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
+    "@libsql/client": "catalog:orm",
     "@react-router/node": "^8.3.0",
     "@tipprunde/db": "workspace:*",
     "@tipprunde/domain": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@libsql/client':
+        specifier: catalog:orm
+        version: 0.17.4
       '@react-router/node':
         specifier: ^8.3.0
         version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)


### PR DESCRIPTION
## Zusammenfassung

Draft-PR für den Legacy-Import: Turso-Client-Wechsel ist drin, das
eigentliche Import-Feature (Manager-Route `/manager/:slug/import`,
JSON-Paste, Upsert-Verhalten) folgt in weiteren Commits.

## Bisher

- Wechsel von `drizzle-orm/libsql/web` (Cloudflare-Workers-Überbleibsel)
  auf `drizzle-orm/libsql` — echte Transaktionen (`db.transaction()`)
  jetzt möglich, App läuft seit dem Railway-Umzug ohnehin auf einem
  echten Node-Server. Nötig für den Import selbst (Multi-Table-Write,
  will Atomarität statt "revert-then-reapply ohne Rollback").

## Noch offen

- Import-Route + Action (admin-only, `/manager/:slug/import`)
- JSON-Verarbeitung: neue Teams/Ligen anlegen, Spieler enrollen,
  Runden/Spiele/Tipps schreiben, Punkte neu berechnen (nie importieren)
- Re-Import-Verhalten: Upsert statt komplettem Löschen+Neuschreiben

🤖 Generated with [Claude Code](https://claude.com/claude-code)