### PR TITLE
fix(web): Format point values in German notation

### DIFF
--- a/apps/web/app/components/ranking-table.tsx
+++ b/apps/web/app/components/ranking-table.tsx
@@ -9,6 +9,7 @@ import { CellFlag } from "#/components/cell-flag.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import type { RankedPlayer } from "#/lib/ranking.server.ts";
 import type { MatchdayTip } from "#/lib/spiele.server.ts";
+import { formatPoints } from "#/lib/utils.ts";
 
 export function RankingTable({
   ranking,
@@ -82,12 +83,12 @@ export function RankingTable({
               </td>
               {showExtras && (
                 <td className="text-subtle xs:px-3 xs:py-3 px-2 py-2 text-center tabular-nums">
-                  {entry.extraQuestionPoints > 0 ? entry.extraQuestionPoints : "–"}
+                  {entry.extraQuestionPoints > 0 ? formatPoints(entry.extraQuestionPoints) : "–"}
                 </td>
               )}
               <td className="xs:px-3 xs:py-3 px-2 py-2 text-center font-medium tabular-nums">
                 <span className="relative inline-block">
-                  {entry.total}
+                  {formatPoints(entry.total)}
                   {entry.roundPoints !== null && (
                     <CellFlag
                       label={`Rundenpunkte: ${entry.roundPoints > 0 ? `+${entry.roundPoints}` : entry.roundPoints}`}

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -22,6 +22,24 @@ export function formatDate(date: string) {
   return d.toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "2-digit" });
 }
 
+/**
+ * Point values in German notation. Only extra-question points are ever
+ * fractional, and always in halves — so a single decimal is enough, and
+ * whole numbers stay free of a pointless ",0".
+ */
+export function formatPoints(points: number): string {
+  return (Number.isInteger(points) ? String(points) : points.toFixed(1)).replace(".", ",");
+}
+
+/**
+ * Per-match averages in German notation. Unlike points these keep both
+ * decimals even when round — an average of exactly "2,00" reads as measured,
+ * "2" reads as counted.
+ */
+export function formatAverage(value: number): string {
+  return value.toFixed(2).replace(".", ",");
+}
+
 export function slugify(value: string): string {
   return value
     .toLowerCase()

--- a/apps/web/app/routes/manager/championship/zusatzfragen.tsx
+++ b/apps/web/app/routes/manager/championship/zusatzfragen.tsx
@@ -13,6 +13,7 @@ import { championshipContext } from "#/lib/context.ts";
 import { db } from "#/lib/db.server.ts";
 import { isLocked } from "#/lib/lock.server.ts";
 import { updateRanking } from "#/lib/ranking.server.ts";
+import { formatPoints } from "#/lib/utils.ts";
 
 import type { Route } from "./+types/zusatzfragen";
 import { LockProvider, useLock } from "./_lock-provider.tsx";
@@ -223,10 +224,6 @@ type EnrolledPlayer = {
   userId: number;
   user: { id: number; name: string };
 };
-
-function formatPoints(points: number): string {
-  return (Number.isInteger(points) ? String(points) : points.toFixed(1)).replace(".", ",");
-}
 
 // --- Question card ---
 

--- a/apps/web/app/routes/public/archiv/index.tsx
+++ b/apps/web/app/routes/public/archiv/index.tsx
@@ -1,5 +1,6 @@
 import { AppLink } from "#/components/app-link.tsx";
 import { getArchivChampionshipList, getEwigeTabelle } from "#/lib/archiv.server.ts";
+import { formatPoints } from "#/lib/utils.ts";
 
 import type { Route } from "./+types/index";
 
@@ -55,7 +56,7 @@ export default function Archiv({ loaderData }: Route.ComponentProps) {
                       )}
                     </td>
                     <td className="py-2 text-right font-medium tabular-nums">
-                      {entry.winners[0]?.total ?? "–"}
+                      {entry.winners[0] ? formatPoints(entry.winners[0].total) : "–"}
                     </td>
                   </tr>
                 ))}
@@ -93,7 +94,7 @@ export default function Archiv({ loaderData }: Route.ComponentProps) {
                         {entry.played}
                       </td>
                       <td className="w-px py-2 pl-3 text-right font-medium tabular-nums">
-                        {entry.totalPoints}
+                        {formatPoints(entry.totalPoints)}
                       </td>
                     </tr>
                   );

--- a/apps/web/app/routes/public/championship/_overview/standings.tsx
+++ b/apps/web/app/routes/public/championship/_overview/standings.tsx
@@ -2,6 +2,7 @@ import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { SectionHeading } from "#/components/section-heading.tsx";
 import type { RankedPlayer } from "#/lib/ranking.server.ts";
+import { formatPoints } from "#/lib/utils.ts";
 
 import { SectionLink } from "./section-link.tsx";
 
@@ -37,7 +38,9 @@ export function ChampionshipStandings({
                 <td className={`py-2 ${isUser ? "text-accent" : ""}`}>
                   <AppLink href={scoped(`/tipps/${entry.slug}`)}>{entry.name}</AppLink>
                 </td>
-                <td className="py-2 text-right font-medium tabular-nums">{entry.total}</td>
+                <td className="py-2 text-right font-medium tabular-nums">
+                  {formatPoints(entry.total)}
+                </td>
               </tr>
             );
           })}
@@ -60,7 +63,9 @@ export function ChampionshipStandings({
                   {userBelowTop3.name}
                 </AppLink>
               </td>
-              <td className="py-2 text-right font-medium tabular-nums">{userBelowTop3.total}</td>
+              <td className="py-2 text-right font-medium tabular-nums">
+                {formatPoints(userBelowTop3.total)}
+              </td>
             </tr>
           </tbody>
         )}

--- a/apps/web/app/routes/public/championship/tipps/_round-item.tsx
+++ b/apps/web/app/routes/public/championship/tipps/_round-item.tsx
@@ -6,7 +6,7 @@ import { CellFlag } from "#/components/cell-flag.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { RoundAccordion } from "#/components/round-accordion.tsx";
 import type { PlayerRound } from "#/lib/spieler.server.ts";
-import { formatDate } from "#/lib/utils.ts";
+import { formatAverage, formatDate } from "#/lib/utils.ts";
 
 export function PlayerRoundItem({
   round,
@@ -23,7 +23,7 @@ export function PlayerRoundItem({
   const roundPoints = round.matches.reduce((sum, m) => sum + (m.tips[0]?.points ?? 0), 0);
   const roundAvg =
     round.tipsPublished && matchesWithResult > 0
-      ? (roundPoints / matchesWithResult).toFixed(2)
+      ? formatAverage(roundPoints / matchesWithResult)
       : null;
   const deviationSum = hasDeviationRule
     ? round.matches

--- a/apps/web/app/routes/public/championship/tipps/index.tsx
+++ b/apps/web/app/routes/public/championship/tipps/index.tsx
@@ -7,6 +7,7 @@ import { getRuleset } from "#/lib/championship.server.ts";
 import { viewedChampionshipContext, userContext } from "#/lib/context.ts";
 import { getRanking, type RankedPlayer, resolvePlayer } from "#/lib/ranking.server.ts";
 import { findUserBySlug, getPlayerMatches, type PlayerRound } from "#/lib/spieler.server.ts";
+import { formatAverage, formatPoints } from "#/lib/utils.ts";
 
 import type { Route } from "./+types/index";
 import { PlayerRoundItem } from "./_round-item.tsx";
@@ -95,7 +96,7 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
   const totalMatches = allMatches.length;
   // Per-match average uses tip points only — extra-question points aren't per-match.
   const playerAvg =
-    matchesWithResult > 0 ? (player.tipPoints / matchesWithResult).toFixed(2) : null;
+    matchesWithResult > 0 ? formatAverage(player.tipPoints / matchesWithResult) : null;
   const playerSpiele =
     matchesWithResult === totalMatches ? `${totalMatches}` : `${matchesWithResult}/${totalMatches}`;
   const lastResultIndex = rounds.findLastIndex((r) => r.matches.some((m) => m.result !== null));
@@ -128,7 +129,8 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
           {(player.extraQuestionPoints > 0 || hasRoundPoints) && (
             <>
               <br />
-              {player.extraQuestionPoints > 0 && `${player.extraQuestionPoints} Zusatzpunkte`}
+              {player.extraQuestionPoints > 0 &&
+                `${formatPoints(player.extraQuestionPoints)} Zusatzpunkte`}
               {player.extraQuestionPoints > 0 && hasRoundPoints && " · "}
               {hasRoundPoints &&
                 `${player.roundPoints! > 0 ? `+${player.roundPoints}` : player.roundPoints! < 0 ? String(player.roundPoints) : "±0"} Rundenpunkte`}

--- a/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
+++ b/apps/web/app/routes/public/championship/verlauf/_bump-chart.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import { PlayerSwitch } from "#/components/player-switch.tsx";
+import { formatPoints } from "#/lib/utils.ts";
 import type { VerlaufPlayer, VerlaufStep } from "#/lib/verlauf.server.ts";
 
 const ROW_HEIGHT = 22;
@@ -259,14 +260,14 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
               {" · Rang "}
               {readout.focus.rank}
               {" · "}
-              <span className="tabular-nums">{readout.focus.points}</span> P
+              <span className="tabular-nums">{formatPoints(readout.focus.points)}</span> P
               {readout.focus.tiedWith.length > 0 && (
                 <> · punktgleich mit {formatTiedWith(readout.focus.tiedWith)}</>
               )}
               {readout.leader && gap > 0 && (
                 <>
                   {" · Rückstand auf "}
-                  {readout.leader.name}: <span className="tabular-nums">{gap}</span> P
+                  {readout.leader.name}: <span className="tabular-nums">{formatPoints(gap)}</span> P
                 </>
               )}
             </>
@@ -509,7 +510,7 @@ export function BumpChart({ steps, playedSteps, players, focusSlug }: Props) {
                   <tr key={i}>
                     <th scope="row">{step ? stepTitle(step) : `Schritt ${i + 1}`}</th>
                     <td>{rank}</td>
-                    <td>{focus.points[i]}</td>
+                    <td>{formatPoints(focus.points[i])}</td>
                   </tr>
                 );
               })}

--- a/apps/web/app/routes/public/championship/zusatzfragen/_question-block.tsx
+++ b/apps/web/app/routes/public/championship/zusatzfragen/_question-block.tsx
@@ -4,6 +4,7 @@ import { AppLink } from "#/components/app-link.tsx";
 import { useScopedPath } from "#/components/championship-scope.tsx";
 import type { ExtraQuestion } from "#/lib/extra-questions.server.ts";
 import type { RankedPlayer } from "#/lib/ranking.server.ts";
+import { formatPoints } from "#/lib/utils.ts";
 
 export function QuestionBlock({
   question,
@@ -54,7 +55,7 @@ export function QuestionBlock({
                 </td>
                 <td className="xs:px-3 px-2 py-3">{answer?.answer ?? "–"}</td>
                 <td className="xs:px-3 w-px px-2 py-3 text-center tabular-nums">
-                  {answer?.points != null ? answer.points : "–"}
+                  {answer?.points != null ? formatPoints(answer.points) : "–"}
                 </td>
               </tr>
             );


### PR DESCRIPTION
Zusatzpunkte sind die einzigen Bruchwerte der App, und jede öffentliche Ansicht hat sie roh ausgegeben — `47.5` statt `47,5`. Die passende Funktion existierte bereits, aber lokal versteckt in der Manager-Zusatzfragen-Seite.

## Was sich ändert

`formatPoints` wandert nach `app/lib/utils.ts` und wird überall dort angewandt, wo ein Bruchwert auftreten kann:

- Ranking-Tabelle (Zusatzpunkte + Gesamt)
- Übersicht-Abschlusstabelle
- Archiv: Sieger-Punkte und Ewige Tabelle
- Spieler-Tipps: Zusatzpunkte
- Zusatzfragen: Punkte pro Antwort
- Verlauf-Readout — **inklusive der Screenreader-Tabelle**, die sonst den englischen Dezimalpunkt vorgelesen hätte

Dazu neu: `formatAverage` für die Ø-Werte, die dasselbe Problem über `toFixed(2)` hatten. Bewusst getrennt von `formatPoints` — ein Durchschnitt behält beide Nachkommastellen auch wenn er glatt aufgeht (`Ø 2,00` liest sich als gemessen, `Ø 2` als gezählt).

Ganzzahlen bleiben ohne `,0`.

## Nicht angefasst

Tipp-Punkte pro Spiel (`match.points`, `tip.points`) und die CellFlag-Label der Verdopplung. Die kommen aus `calcTipPoints` und sind immer ganzzahlig.

## Verifikation

Im Browser gegen die Dev-DB geprüft (`hr0506`, Falk hat dort 1,5 Zusatzpunkte): Tabelle, Spieler-Tipps, Runden-Meta, Zusatzfragen, Ewige Tabelle und Verlauf-Readout zeigen jetzt alle Komma. Typecheck grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)