### PR TITLE
fix(web): Scroll to the top when editing a match

### DIFF
--- a/apps/web/app/routes/manager/championship/spiele.tsx
+++ b/apps/web/app/routes/manager/championship/spiele.tsx
@@ -8,7 +8,7 @@ import { Button, Card, CardContent, DateField, Label } from "@tipprunde/ui";
 import { cx } from "@tipprunde/ui";
 import { desc, eq, max } from "drizzle-orm";
 import { PencilIcon, PlusIcon } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Button as RACButton,
   ComboBox,
@@ -441,8 +441,23 @@ export default function Spiele({ loaderData }: Route.ComponentProps) {
   const navigate = useNavigate();
   const [editMatch, setEditMatch] = useState<MatchRow | null>(null);
   const [createKey, setCreateKey] = useState(0);
+  const pageRef = useRef<HTMLDivElement>(null);
 
   const formKey = editMatch ? `edit-${editMatch.id}` : `create-${createKey}`;
+
+  // The form sits above the list, so editing a match far down the round would
+  // otherwise fill in a card the user cannot see. Scrolls the page rather than
+  // the form itself, which would leave the round navigator behind the header.
+  // Has to run after the render, not in the click handler: on a completed round
+  // the form does not exist until `editMatch` makes `showForm` true.
+  const editId = editMatch?.id ?? null;
+  useEffect(() => {
+    if (editId === null) return;
+    pageRef.current?.scrollIntoView({
+      behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+      block: "start",
+    });
+  }, [editId]);
 
   const handleDone = useCallback(() => {
     setEditMatch(null);
@@ -463,7 +478,7 @@ export default function Spiele({ loaderData }: Route.ComponentProps) {
   const showForm = !isChampionshipCompleted && (!isRoundCompleted || editMatch !== null);
 
   return (
-    <div className="space-y-6 p-8">
+    <div ref={pageRef} className="space-y-6 p-8">
       <title>{`Spiele | ${championshipName}`}</title>
       <div className="mb-6 flex min-h-9 items-center">
         <RoundNavigator


### PR DESCRIPTION
Das Formular sitzt über der Liste. Ein Klick auf den Stift bei einem Spiel weiter unten in der Runde hat also eine Card befüllt, die außerhalb des Sichtfelds lag — sichtbar passierte nichts.

## Warum so und nicht anders

**Gescrollt wird der Seiten-Container, nicht das Formular.** Gemessen landet `scrollIntoView` auf der Form-Card bei `scrollTop: 92` — die Card klebt dann unter dem Header und der Runden-Navigator ("Runde 4 von 4") ist weg. Am Container sind es `0`, also echtes „nach oben", Navigator bleibt sichtbar.

**Der Scroll läuft im Effect, nicht im Click-Handler.** Bei abgeschlossener Runde existiert das Formular im Moment des Klicks noch gar nicht — erst `editMatch` schaltet `showForm` an. Im Handler wäre der Ref dort `null`.

`prefers-reduced-motion` schaltet auf `auto` statt `smooth`.

## Umfang

Betrifft strukturell nur diese Seite. Die Stammdaten-Seiten (Teams, Ligen, Spieler, Turniere, Regelwerke) nutzen Dialoge und haben das Problem nicht.

## Verifikation

Vom Autor lokal durchgeklickt und bestätigt. Der Mechanismus zusätzlich im Dev-Server gemessen (`main` von `scrollTop` 305 auf 0). Typecheck grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)