### PR TITLE
feat(web): Make the manager usable on a phone

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -69,7 +69,13 @@
       ]
     },
     "JavaScript": {
-      "language_servers": ["typescript-ls", "!vtsls", "!eslint", "..."],
+      "language_servers": [
+        "typescript-ls",
+        "!vtsls",
+        "!typescript-language-server",
+        "!eslint",
+        "..."
+      ],
       "format_on_save": "on",
       "prettier": {
         "allowed": false
@@ -109,7 +115,13 @@
       ]
     },
     "TypeScript": {
-      "language_servers": ["typescript-ls", "!vtsls", "!eslint", "..."],
+      "language_servers": [
+        "typescript-ls",
+        "!vtsls",
+        "!typescript-language-server",
+        "!eslint",
+        "..."
+      ],
       "format_on_save": "on",
       "prettier": {
         "allowed": false
@@ -123,7 +135,13 @@
       ]
     },
     "TSX": {
-      "language_servers": ["typescript-ls", "!vtsls", "!eslint", "..."],
+      "language_servers": [
+        "typescript-ls",
+        "!vtsls",
+        "!typescript-language-server",
+        "!eslint",
+        "..."
+      ],
       "format_on_save": "on",
       "prettier": {
         "allowed": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.4.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.3.0...v1.4.0)
+
+### 🚀 Enhancements
+
+- **web:** Make the manager match page usable on a phone ([f9ae316](https://github.com/haus23/tipprunde/commit/f9ae316))
+- **web:** Stack the round switches on narrow screens ([812cc4d](https://github.com/haus23/tipprunde/commit/812cc4d))
+- **web:** Drop email and role from the player list on phones ([a315ca1](https://github.com/haus23/tipprunde/commit/a315ca1))
+- **web:** Give the extra-question answer its own row on phones ([efd46c7](https://github.com/haus23/tipprunde/commit/efd46c7))
+- **web:** Label the extra-question columns and mend the read-only view ([1ff6ab2](https://github.com/haus23/tipprunde/commit/1ff6ab2))
+- **web:** Enlarge the joker checkbox hit area for touch ([9de43d5](https://github.com/haus23/tipprunde/commit/9de43d5))
+- **web:** Enlarge the round navigator arrows for touch ([d4aedb5](https://github.com/haus23/tipprunde/commit/d4aedb5))
+- **web:** Drop the crowded-out columns from two master-data lists ([6298403](https://github.com/haus23/tipprunde/commit/6298403))
+- **web:** Put the switches and checkbox on the project's easing curve ([6f4f5fd](https://github.com/haus23/tipprunde/commit/6f4f5fd))
+
+### 💅 Refactors
+
+- **web:** Move the manager page padding into the layout ([ca1d6dd](https://github.com/haus23/tipprunde/commit/ca1d6dd))
+
+### 🏡 Chore
+
+- Stop Zed from starting a second TypeScript server ([32b1d4e](https://github.com/haus23/tipprunde/commit/32b1d4e))
+
 ## v1.3.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.2.0...v1.3.0)

--- a/apps/web/app/routes/manager/_error-content.tsx
+++ b/apps/web/app/routes/manager/_error-content.tsx
@@ -11,7 +11,7 @@ export function ManagerErrorContent() {
   const isNotFound = isRouteErrorResponse(error) && error.status === 404;
 
   return (
-    <div className="flex min-h-full flex-col items-center justify-center gap-3 p-8 text-center">
+    <div className="flex min-h-full flex-col items-center justify-center gap-3 text-center">
       {/* The replaced route component would have rendered the document title. */}
       <title>{isNotFound ? "Nicht gefunden | Manager" : "Fehler | Manager"}</title>
       <h1 className="text-xl font-semibold">

--- a/apps/web/app/routes/manager/_layout.tsx
+++ b/apps/web/app/routes/manager/_layout.tsx
@@ -127,7 +127,7 @@ function Shell({ loaderData }: { loaderData: Route.ComponentProps["loaderData"] 
           <ColorSchemeToggle />
         </div>
       </header>
-      <main className="relative overflow-y-auto">
+      <main className="relative overflow-y-auto px-2 py-6 sm:p-8">
         <Outlet />
       </main>
     </div>

--- a/apps/web/app/routes/manager/championship/_round-navigator.tsx
+++ b/apps/web/app/routes/manager/championship/_round-navigator.tsx
@@ -11,6 +11,13 @@ export function RoundNavigator({ currentNr, totalRounds, onNavigate }: RoundNavi
   const hasPrev = currentNr > 1;
   const hasNext = currentNr < totalRounds;
 
+  /**
+   * The icon size gives a 28px button, which is small for a finger. Only grown
+   * below sm: on a pointer device 28px is fine, and the row this sits in is the
+   * same one on three pages — no reason to make it taller everywhere.
+   */
+  const hitArea = "p-3 sm:p-1.5";
+
   return (
     <div className="flex items-center gap-1">
       <Button
@@ -19,6 +26,7 @@ export function RoundNavigator({ currentNr, totalRounds, onNavigate }: RoundNavi
         isDisabled={!hasPrev}
         onPress={() => onNavigate(currentNr - 1)}
         aria-label="Vorherige Runde"
+        className={hitArea}
       >
         <ChevronLeftIcon className="size-4" />
       </Button>
@@ -31,6 +39,7 @@ export function RoundNavigator({ currentNr, totalRounds, onNavigate }: RoundNavi
         isDisabled={!hasNext}
         onPress={() => onNavigate(currentNr + 1)}
         aria-label="Nächste Runde"
+        className={hitArea}
       >
         <ChevronRightIcon className="size-4" />
       </Button>

--- a/apps/web/app/routes/manager/championship/ergebnisse.tsx
+++ b/apps/web/app/routes/manager/championship/ergebnisse.tsx
@@ -253,7 +253,7 @@ export default function Ergebnisse({ loaderData }: Route.ComponentProps) {
 
   if (currentNr === null) {
     return (
-      <div className="space-y-6 p-8">
+      <div className="space-y-6">
         <title>{`Ergebnisse | ${championshipName}`}</title>
         <div className="mb-6 flex min-h-9 items-center" />
         <p className="text-subtle text-center text-sm">Noch keine Runden angelegt.</p>
@@ -264,7 +264,7 @@ export default function Ergebnisse({ loaderData }: Route.ComponentProps) {
   const { matches, isChampionshipClosed, isRoundClosed, slug } = loaderData;
 
   return (
-    <div className="space-y-6 p-8">
+    <div className="space-y-6">
       <title>{`Ergebnisse | ${championshipName}`}</title>
       <div className="mb-6 flex min-h-9 items-center">
         <RoundNavigator

--- a/apps/web/app/routes/manager/championship/import.tsx
+++ b/apps/web/app/routes/manager/championship/import.tsx
@@ -63,7 +63,7 @@ export default function Import() {
   const summary = fetcher.data?.summary;
 
   return (
-    <div className="p-8">
+    <div>
       <title>Legacy-Import</title>
       <div className="max-w-2xl">
         <Card>

--- a/apps/web/app/routes/manager/championship/index.tsx
+++ b/apps/web/app/routes/manager/championship/index.tsx
@@ -444,9 +444,11 @@ function RoundRow({ round, roundRuleId }: { round: Round; roundRuleId: RoundRule
   const completedDisabled = isChampionshipLocked || isPending || !tipsPublished;
 
   return (
-    <div className="flex items-center gap-4 py-3">
-      <span className="text-muted w-8 text-right text-sm tabular-nums">{round.nr}</span>
-      <div className="flex flex-1 gap-6">
+    <div className="flex items-start gap-4 py-3 sm:items-center">
+      <span className="text-muted w-8 shrink-0 text-right text-sm tabular-nums">{round.nr}</span>
+      {/* Three switches abreast need ~410px; below sm they stack instead of
+          running off the right edge, which cut "Abgeschlossen" in half. */}
+      <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:gap-6">
         <CompactSwitch
           label="Spiele öffentlich"
           isSelected={published}
@@ -522,7 +524,7 @@ export default function ChampionshipIndex({ loaderData }: Route.ComponentProps) 
     isFlagPending || !published || (hasExtraQuestions && !extraQuestionPointsPublished);
 
   return (
-    <div className="space-y-6 p-8">
+    <div className="space-y-6 px-2 py-6 sm:p-8">
       <title>{`Übersicht | ${championship.name}`}</title>
 
       {/* Turnier-Status */}

--- a/apps/web/app/routes/manager/championship/index.tsx
+++ b/apps/web/app/routes/manager/championship/index.tsx
@@ -524,7 +524,7 @@ export default function ChampionshipIndex({ loaderData }: Route.ComponentProps) 
     isFlagPending || !published || (hasExtraQuestions && !extraQuestionPointsPublished);
 
   return (
-    <div className="space-y-6 px-2 py-6 sm:p-8">
+    <div className="space-y-6">
       <title>{`Übersicht | ${championship.name}`}</title>
 
       {/* Turnier-Status */}

--- a/apps/web/app/routes/manager/championship/index.tsx
+++ b/apps/web/app/routes/manager/championship/index.tsx
@@ -328,13 +328,13 @@ function FlagSwitch({ label, description, isSelected, onChange, isDisabled }: Fl
           <>
             <div
               className={cx(
-                "flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors",
+                "flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ease-out",
                 isSelected ? "border-accent bg-accent" : "border-subtle bg-surface",
               )}
             >
               <div
                 className={cx(
-                  "ml-0.5 size-4 rounded-full transition-transform",
+                  "ml-0.5 size-4 rounded-full transition-transform ease-out",
                   isSelected ? "translate-x-4 bg-white" : "bg-control",
                 )}
               />
@@ -373,13 +373,13 @@ function CompactSwitch({ label, isSelected, onChange, isDisabled }: CompactSwitc
           <>
             <div
               className={cx(
-                "flex h-4 w-7 shrink-0 items-center rounded-full border transition-colors",
+                "flex h-4 w-7 shrink-0 items-center rounded-full border transition-colors ease-out",
                 isSelected ? "border-accent bg-accent" : "border-subtle bg-surface",
               )}
             >
               <div
                 className={cx(
-                  "ml-0.5 size-3 rounded-full transition-transform",
+                  "ml-0.5 size-3 rounded-full transition-transform ease-out",
                   isSelected ? "translate-x-3 bg-white" : "bg-control",
                 )}
               />

--- a/apps/web/app/routes/manager/championship/spiele.tsx
+++ b/apps/web/app/routes/manager/championship/spiele.tsx
@@ -303,8 +303,23 @@ function MatchForm({ roundId, editMatch, defaultDate, teams, leagues, onDone }: 
         <input type="hidden" name="intent" value={isEdit ? "update-match" : "create-match"} />
         <input type="hidden" name="roundId" value={roundId} />
 
-        <div className="grid grid-cols-4 gap-4">
-          <DateField name="date" label="Datum" defaultValue={editMatch?.date ?? defaultDate} />
+        {/* Three steps, and the last one is late on purpose. The date field has
+            a hard minimum of 137px, so four columns need ~596px of grid — and
+            from md the sidebar takes 208px off the viewport, leaving only 448px
+            here at 768px. Four abreast therefore waits for lg; in between the
+            date and league share a row, the pairing the next. At lg the columns
+            are sized to what they hold: the date takes only its segments, the
+            league its short codes ("BL", "WM Quali"), and the two team boxes
+            split what is left — those carry the long values. */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-[auto_0.6fr_1fr_1fr]">
+          {/* Sized to its own segments instead of stretching — a date is short
+              and a full-width box for "20.12.2005" reads as an error. */}
+          <DateField
+            name="date"
+            label="Datum"
+            defaultValue={editMatch?.date ?? defaultDate}
+            className="justify-self-start"
+          />
 
           <MatchComboBox
             name="leagueId"
@@ -387,9 +402,9 @@ function MatchesTable({
       <thead>
         <tr className="border-subtle border-b">
           <th className="text-muted pr-4 pb-3 text-right font-medium">#</th>
-          <th className="text-muted pr-4 pb-3 text-left font-medium">Datum</th>
+          <th className="text-muted xs:table-cell hidden pr-4 pb-3 text-left font-medium">Datum</th>
           <th className="text-muted pr-4 pb-3 text-left font-medium">Spiel</th>
-          <th className="text-muted pb-3 text-left font-medium">Liga</th>
+          <th className="text-muted xs:table-cell hidden pb-3 text-left font-medium">Liga</th>
           {canEdit && <th />}
         </tr>
       </thead>
@@ -397,11 +412,19 @@ function MatchesTable({
         {matches.map((match) => (
           <tr key={match.id} className="border-subtle border-b last:border-0">
             <td className="text-muted py-3 pr-4 text-right tabular-nums">{match.nr}</td>
-            <td className="py-3 pr-4 tabular-nums">{match.date ? formatDate(match.date) : "—"}</td>
+            <td className="xs:table-cell hidden py-3 pr-4 tabular-nums">
+              {match.date ? formatDate(match.date) : "—"}
+            </td>
             <td className="py-3 pr-4">
               {match.hometeam?.name ?? "?"} – {match.awayteam?.name ?? "?"}
+              {/* Below xs the date and league columns are gone; they come back
+                  here as a meta line rather than being dropped entirely. */}
+              <span className="text-muted xs:hidden mt-0.5 block text-xs">
+                <span className="tabular-nums">{match.date ? formatDate(match.date) : "—"}</span>
+                {match.league?.shortName && ` · ${match.league.shortName}`}
+              </span>
             </td>
-            <td className="py-3">{match.league?.shortName ?? "—"}</td>
+            <td className="xs:table-cell hidden py-3">{match.league?.shortName ?? "—"}</td>
             {canEdit && (
               <td className="py-3 text-right">
                 <Button
@@ -466,7 +489,7 @@ export default function Spiele({ loaderData }: Route.ComponentProps) {
 
   if (currentNr === null) {
     return (
-      <div className="space-y-6 p-8">
+      <div className="space-y-6 px-2 py-6 sm:p-8">
         <title>{`Spiele | ${championshipName}`}</title>
         <div className="mb-6 flex min-h-9 items-center" />
         <p className="text-subtle text-center text-sm">Noch keine Runden angelegt.</p>
@@ -478,7 +501,7 @@ export default function Spiele({ loaderData }: Route.ComponentProps) {
   const showForm = !isChampionshipCompleted && (!isRoundCompleted || editMatch !== null);
 
   return (
-    <div ref={pageRef} className="space-y-6 p-8">
+    <div ref={pageRef} className="space-y-6 px-2 py-6 sm:p-8">
       <title>{`Spiele | ${championshipName}`}</title>
       <div className="mb-6 flex min-h-9 items-center">
         <RoundNavigator

--- a/apps/web/app/routes/manager/championship/spiele.tsx
+++ b/apps/web/app/routes/manager/championship/spiele.tsx
@@ -489,7 +489,7 @@ export default function Spiele({ loaderData }: Route.ComponentProps) {
 
   if (currentNr === null) {
     return (
-      <div className="space-y-6 px-2 py-6 sm:p-8">
+      <div className="space-y-6">
         <title>{`Spiele | ${championshipName}`}</title>
         <div className="mb-6 flex min-h-9 items-center" />
         <p className="text-subtle text-center text-sm">Noch keine Runden angelegt.</p>
@@ -501,7 +501,7 @@ export default function Spiele({ loaderData }: Route.ComponentProps) {
   const showForm = !isChampionshipCompleted && (!isRoundCompleted || editMatch !== null);
 
   return (
-    <div ref={pageRef} className="space-y-6 px-2 py-6 sm:p-8">
+    <div ref={pageRef} className="space-y-6">
       <title>{`Spiele | ${championshipName}`}</title>
       <div className="mb-6 flex min-h-9 items-center">
         <RoundNavigator

--- a/apps/web/app/routes/manager/championship/tipps.tsx
+++ b/apps/web/app/routes/manager/championship/tipps.tsx
@@ -627,7 +627,7 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
 
   if (players.length === 0) {
     return (
-      <div className="space-y-6 p-8">
+      <div className="space-y-6">
         <title>{`Tipps | ${championshipName}`}</title>
         <div className="mb-6 flex min-h-9 items-center" />
         <p className="text-subtle text-center text-sm">Noch keine Spieler im Turnier.</p>
@@ -637,7 +637,7 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
 
   if (rounds.length === 0) {
     return (
-      <div className="space-y-6 p-8">
+      <div className="space-y-6">
         <title>{`Tipps | ${championshipName}`}</title>
         <div className="mb-6 flex min-h-9 items-center" />
         <p className="text-subtle text-center text-sm">Noch keine Spiele angelegt.</p>
@@ -655,7 +655,7 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
   const extraJokerCount = allMatches.filter((m) => m.tips[0]?.extraJoker).length;
 
   return (
-    <div className="space-y-6 p-8">
+    <div className="space-y-6">
       <title>{`Tipps | ${championshipName}`}</title>
       <div className="mb-6 flex min-h-9 items-center">
         <RoundNavigator

--- a/apps/web/app/routes/manager/championship/tipps.tsx
+++ b/apps/web/app/routes/manager/championship/tipps.tsx
@@ -302,6 +302,15 @@ function normalizeTip(raw: string): string {
   return raw.replace(/\s+/g, "").replace(/[-.]/g, ":").replace(/:+/g, ":");
 }
 
+/**
+ * The checkbox itself is 20px, which is a small target for a finger. The
+ * padding grows the hit area to 36x44 without touching the visual size; the
+ * negative margin cancels it again for layout, so nothing moves. Not the full
+ * 44 wide on purpose — the joker and extra-joker cells are 45px and 42px, and
+ * two 44px targets side by side would start catching each other's taps.
+ */
+const jokerHitArea = "-mx-2 -my-3 px-2 py-3";
+
 type TipEntry = { tip: string; joker: boolean; extraJoker: boolean; invalid?: boolean };
 
 type TipMatch = {
@@ -579,6 +588,7 @@ function TipRow({
       </td>
       <td className="py-3 pl-2 text-center">
         <Checkbox
+          className={jokerHitArea}
           isSelected={entry.joker}
           isDisabled={isEntryLocked || !isJokerAllowed}
           onChange={(checked) => {
@@ -592,6 +602,7 @@ function TipRow({
       {hasExtraJoker && (
         <td className="py-3 pl-2 text-center">
           <Checkbox
+            className={jokerHitArea}
             isSelected={entry.extraJoker}
             isDisabled={isEntryLocked || !isExtraJokerAllowed}
             onChange={(checked) => {

--- a/apps/web/app/routes/manager/championship/zusatzfragen.tsx
+++ b/apps/web/app/routes/manager/championship/zusatzfragen.tsx
@@ -379,7 +379,16 @@ function QuestionCard({
             summaryClassName="px-2 py-1.5 hover:bg-transparent"
             bodyClassName="mt-2 pb-0"
           >
-            <div className="space-y-2 py-0.5">
+            {/* Desktop had no labels at all — only position said which column was
+                which. Below sm the rows stack, so they carry their own labels
+                and get dividers instead: without the input borders of the
+                editable state there is nothing else grouping one player. */}
+            <div className="text-muted hidden grid-cols-[8rem_1fr_auto] gap-x-3 pb-1.5 text-xs font-medium tracking-wide uppercase sm:grid">
+              <span>Spieler</span>
+              <span>Antwort</span>
+              <span className="w-14 text-center">Punkte</span>
+            </div>
+            <div className="divide-subtle divide-y py-0.5 sm:space-y-2 sm:divide-y-0">
               {players.map((player) => (
                 <PlayerAnswerRow
                   key={player.userId}
@@ -481,40 +490,70 @@ function PlayerAnswerRow({
 
            Spieler              [Pkt]
            [        Antwort        ]  */
-    <div className="grid grid-cols-[1fr_auto] items-center gap-x-3 gap-y-1.5 sm:grid-cols-[8rem_1fr_auto] sm:gap-y-0">
+    <div className="grid grid-cols-[1fr_auto] items-center gap-x-3 gap-y-1 py-2 sm:grid-cols-[8rem_1fr_auto] sm:gap-y-0 sm:py-0">
       <span className="col-start-1 row-start-1 min-w-0 truncate text-sm">{player.user.name}</span>
       {isChampionshipClosed ? (
         <>
+          {/* No leading label here: a label beside a three-line answer floats in
+              the middle of it and eats the width the long ones need. The unit
+              on the points identifies them instead, so the other value can
+              only be the answer. */}
           <span className={cx(answerCellClass, "text-sm")}>{extraAnswer?.answer || "–"}</span>
-          <span className={cx(pointsCellClass, "w-14 text-center text-sm tabular-nums")}>
-            {extraAnswer?.points != null ? formatPoints(extraAnswer.points) : "–"}
+          <span
+            className={cx(
+              pointsCellClass,
+              "justify-self-end text-sm tabular-nums",
+              "sm:w-14 sm:justify-self-auto sm:text-center",
+            )}
+          >
+            {extraAnswer?.points != null ? (
+              <>
+                {formatPoints(extraAnswer.points)}
+                <span className="text-muted text-xs sm:hidden"> Pkt</span>
+              </>
+            ) : (
+              "–"
+            )}
           </span>
         </>
       ) : (
         <>
-          <TextField
-            aria-label={`Antwort von ${player.user.name}`}
-            value={answerInput}
-            onChange={setAnswerInput}
-            onBlur={handleSaveAnswer}
-            className={answerCellClass}
-          >
-            <Input placeholder="Keine Antwort ..." className="w-full" />
-          </TextField>
-          <TextField
-            aria-label={`Punkte für ${player.user.name}`}
-            value={pointsInput}
-            onChange={setPointsInput}
-            onBlur={handleSavePoints}
-            className={pointsCellClass}
-          >
-            <Input
-              inputMode="decimal"
-              onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-              placeholder="Pkt."
-              className="w-14 text-center"
-            />
-          </TextField>
+          <div className={cx(answerCellClass, "flex items-center gap-1.5")}>
+            {/* Stacked, the answer and the points are two bare numbers under
+                each other and position no longer says which is which — the
+                "Pkt." placeholder is gone exactly when a value is present.
+                Decorative only: both fields carry an aria-label already. */}
+            <span className="text-muted shrink-0 text-xs sm:hidden" aria-hidden="true">
+              Antwort
+            </span>
+            <TextField
+              aria-label={`Antwort von ${player.user.name}`}
+              value={answerInput}
+              onChange={setAnswerInput}
+              onBlur={handleSaveAnswer}
+              className="min-w-0 flex-1"
+            >
+              <Input placeholder="Keine Antwort ..." className="w-full" />
+            </TextField>
+          </div>
+          <div className={cx(pointsCellClass, "flex items-center gap-1.5")}>
+            <span className="text-muted shrink-0 text-xs sm:hidden" aria-hidden="true">
+              Pkt
+            </span>
+            <TextField
+              aria-label={`Punkte für ${player.user.name}`}
+              value={pointsInput}
+              onChange={setPointsInput}
+              onBlur={handleSavePoints}
+            >
+              <Input
+                inputMode="decimal"
+                onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
+                aria-label={`Punkte für ${player.user.name}`}
+                className="w-14 text-center"
+              />
+            </TextField>
+          </div>
         </>
       )}
     </div>

--- a/apps/web/app/routes/manager/championship/zusatzfragen.tsx
+++ b/apps/web/app/routes/manager/championship/zusatzfragen.tsx
@@ -517,7 +517,7 @@ export default function Zusatzfragen({ loaderData }: Route.ComponentProps) {
 
   if (!hasExtraQuestions) {
     return (
-      <div className="p-8">
+      <div>
         <title>{`Zusatzfragen | ${championshipName}`}</title>
         <div className="mb-6 flex min-h-9 items-center" />
         <p className="text-subtle mt-8 text-center text-sm">
@@ -528,7 +528,7 @@ export default function Zusatzfragen({ loaderData }: Route.ComponentProps) {
   }
 
   return (
-    <div className="space-y-6 p-8">
+    <div className="space-y-6">
       <title>{`Zusatzfragen | ${championshipName}`}</title>
       <div className="mb-6 flex min-h-9 items-center justify-end">
         <Button

--- a/apps/web/app/routes/manager/championship/zusatzfragen.tsx
+++ b/apps/web/app/routes/manager/championship/zusatzfragen.tsx
@@ -397,6 +397,11 @@ function QuestionCard({
 }
 
 // Each row owns its own fetcher (keyed via useId() internally) so that
+/** Grid placement, shared by the read-only and the editable branch. */
+const answerCellClass =
+  "col-span-2 row-start-2 min-w-0 sm:col-span-1 sm:col-start-2 sm:row-start-1";
+const pointsCellClass = "col-start-2 row-start-1 sm:col-start-3";
+
 // saving one player's answer/points can never abort another's in-flight save.
 function PlayerAnswerRow({
   questionId,
@@ -468,12 +473,20 @@ function PlayerAnswerRow({
   }
 
   return (
-    <div className="flex items-center gap-3">
-      <span className="w-32 shrink-0 truncate text-sm">{player.user.name}</span>
+    /* Below sm the answer moves to its own row and takes the full width:
+       awarding points means reading the answer, and sharing one row with the
+       name and the points box left it under 110px on a phone. Name and points
+       keep the row above — everything else about the answer is unreadable
+       without them side by side.
+
+           Spieler              [Pkt]
+           [        Antwort        ]  */
+    <div className="grid grid-cols-[1fr_auto] items-center gap-x-3 gap-y-1.5 sm:grid-cols-[8rem_1fr_auto] sm:gap-y-0">
+      <span className="col-start-1 row-start-1 min-w-0 truncate text-sm">{player.user.name}</span>
       {isChampionshipClosed ? (
         <>
-          <span className="min-w-0 flex-1 text-sm">{extraAnswer?.answer || "–"}</span>
-          <span className="w-14 shrink-0 text-center text-sm tabular-nums">
+          <span className={cx(answerCellClass, "text-sm")}>{extraAnswer?.answer || "–"}</span>
+          <span className={cx(pointsCellClass, "w-14 text-center text-sm tabular-nums")}>
             {extraAnswer?.points != null ? formatPoints(extraAnswer.points) : "–"}
           </span>
         </>
@@ -484,7 +497,7 @@ function PlayerAnswerRow({
             value={answerInput}
             onChange={setAnswerInput}
             onBlur={handleSaveAnswer}
-            className="min-w-0 flex-1"
+            className={answerCellClass}
           >
             <Input placeholder="Keine Antwort ..." className="w-full" />
           </TextField>
@@ -493,7 +506,7 @@ function PlayerAnswerRow({
             value={pointsInput}
             onChange={setPointsInput}
             onBlur={handleSavePoints}
-            className="shrink-0"
+            className={pointsCellClass}
           >
             <Input
               inputMode="decimal"

--- a/apps/web/app/routes/manager/ligen.tsx
+++ b/apps/web/app/routes/manager/ligen.tsx
@@ -62,7 +62,7 @@ export default function Ligen({ loaderData }: Route.ComponentProps) {
   );
 
   return (
-    <div className="p-8">
+    <div>
       <title>Ligen | Stammdaten</title>
       <div className="mb-6 flex min-h-9 items-center justify-between gap-4">
         <SearchField

--- a/apps/web/app/routes/manager/regelwerke.tsx
+++ b/apps/web/app/routes/manager/regelwerke.tsx
@@ -95,7 +95,9 @@ export default function Regelwerke({ loaderData }: Route.ComponentProps) {
             <th className="border-subtle text-muted w-56 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Name
             </th>
-            <th className="border-subtle text-muted border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
+            {/* 85px of description at 375px is a truncated fragment, not
+                information — the name carries the row instead. */}
+            <th className="border-subtle text-muted xs:table-cell hidden border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Beschreibung
             </th>
             <th className="border-subtle w-12 border-b" />
@@ -115,7 +117,7 @@ export default function Regelwerke({ loaderData }: Route.ComponentProps) {
                 className="border-subtle hover:bg-surface-raised border-b transition-colors last:border-0"
               >
                 <td className="px-3 py-3 font-medium">{ruleset.name}</td>
-                <td className="px-3 py-3">
+                <td className="xs:table-cell hidden px-3 py-3">
                   <div className="text-subtle truncate text-sm">{ruleset.description}</div>
                 </td>
                 <td className="px-3 py-3 text-right">

--- a/apps/web/app/routes/manager/regelwerke.tsx
+++ b/apps/web/app/routes/manager/regelwerke.tsx
@@ -74,7 +74,7 @@ export default function Regelwerke({ loaderData }: Route.ComponentProps) {
   );
 
   return (
-    <div className="p-8">
+    <div>
       <title>Regelwerke | Stammdaten</title>
       <div className="mb-6 flex min-h-9 items-center justify-between gap-4">
         <SearchField

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -85,7 +85,7 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
   );
 
   return (
-    <div className="p-8">
+    <div>
       <title>Spieler | Stammdaten</title>
       <div className="mb-6 flex min-h-9 items-center justify-between gap-4">
         <SearchField

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -106,10 +106,14 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
             <th className="border-subtle text-muted border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Name
             </th>
-            <th className="border-subtle text-muted w-56 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
+            {/* Both drop out below xs: the fixed widths alone (224 + 112 + 48)
+                already exceed a 375px screen. The address is not lost — the
+                edit dialog shows it, which is where a change request ends up
+                anyway. */}
+            <th className="border-subtle text-muted xs:table-cell hidden w-56 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               E-Mail
             </th>
-            <th className="border-subtle text-muted w-28 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
+            <th className="border-subtle text-muted xs:table-cell hidden w-28 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Rolle
             </th>
             <th className="border-subtle w-12 border-b" />
@@ -132,8 +136,10 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
                   <div className="font-medium">{user.name}</div>
                   <div className="text-subtle font-mono text-xs">{user.slug}</div>
                 </td>
-                <td className="text-subtle px-3 py-3">{user.email}</td>
-                <td className="text-subtle px-3 py-3">{roleLabels[user.role]}</td>
+                <td className="text-subtle xs:table-cell hidden px-3 py-3">{user.email}</td>
+                <td className="text-subtle xs:table-cell hidden px-3 py-3">
+                  {roleLabels[user.role]}
+                </td>
                 <td className="px-3 py-3 text-right">
                   <Button
                     intent="ghost"

--- a/apps/web/app/routes/manager/start.tsx
+++ b/apps/web/app/routes/manager/start.tsx
@@ -16,7 +16,7 @@ export default function Start({ loaderData }: Route.ComponentProps) {
   const { hasRulesets } = loaderData;
 
   return (
-    <div className="flex h-full items-center justify-center p-8">
+    <div className="flex h-full items-center justify-center">
       <title>Manager | runde.tips</title>
       <div className="w-full max-w-lg">
         {hasRulesets ? (

--- a/apps/web/app/routes/manager/teams.tsx
+++ b/apps/web/app/routes/manager/teams.tsx
@@ -62,7 +62,7 @@ export default function Teams({ loaderData }: Route.ComponentProps) {
   );
 
   return (
-    <div className="p-8">
+    <div>
       <title>Teams | Stammdaten</title>
       <div className="mb-6 flex min-h-9 items-center justify-between gap-4">
         <SearchField

--- a/apps/web/app/routes/manager/turniere.tsx
+++ b/apps/web/app/routes/manager/turniere.tsx
@@ -97,7 +97,7 @@ export default function Turniere({ loaderData }: Route.ComponentProps) {
   );
 
   return (
-    <div className="p-8">
+    <div>
       <title>Turniere | Stammdaten</title>
       <div className="mb-6 flex min-h-9 items-center justify-between gap-4">
         <SearchField

--- a/apps/web/app/routes/manager/turniere.tsx
+++ b/apps/web/app/routes/manager/turniere.tsx
@@ -121,7 +121,11 @@ export default function Turniere({ loaderData }: Route.ComponentProps) {
             <th className="border-subtle text-muted border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Name
             </th>
-            <th className="border-subtle text-muted w-48 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
+            {/* table-fixed reserves 64 + 192 + 48 for the other three, leaving
+                the name 55px at 375px — and the name has no truncate, so it ran
+                straight over the ruleset text. Dropping this column below xs
+                gives the name the room; the edit dialog shows the ruleset. */}
+            <th className="border-subtle text-muted xs:table-cell hidden w-48 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Regelwerk
             </th>
             <th className="border-subtle w-12 border-b" />
@@ -145,7 +149,7 @@ export default function Turniere({ loaderData }: Route.ComponentProps) {
                   <div className="font-medium">{championship.name}</div>
                   <div className="text-subtle font-mono text-xs">{championship.slug}</div>
                 </td>
-                <td className="px-3 py-3">
+                <td className="xs:table-cell hidden px-3 py-3">
                   <div className="text-subtle truncate text-sm">{championship.ruleset?.name}</div>
                 </td>
                 <td className="px-3 py-3 text-right">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -37,9 +37,16 @@ export function Checkbox({ className, children, ...props }: Props) {
   return (
     <CheckboxField {...props}>
       <CheckboxButton
-        className={cx("group inline-flex items-center gap-2 data-disabled:opacity-50", className)}
+        className={cx(
+          "group inline-flex items-center gap-2 data-disabled:opacity-50",
+          // Same press feedback and curve as Button — a tap that only changes a
+          // colour reads as if nothing was registered, the more so now that the
+          // hit area is larger than the box.
+          "transition-transform ease-out data-pressed:scale-[0.97]",
+          className,
+        )}
       >
-        <span className="border-subtle group-data-selected:border-accent group-data-selected:bg-accent group-data-focus-visible:ring-accent flex size-5 shrink-0 items-center justify-center rounded border transition-colors outline-none group-data-focus-visible:ring-2">
+        <span className="border-subtle group-data-selected:border-accent group-data-selected:bg-accent group-data-focus-visible:ring-accent flex size-5 shrink-0 items-center justify-center rounded border transition-colors ease-out outline-none group-data-focus-visible:ring-2">
           <CheckMark />
         </span>
         {children && <span className="text-app select-none">{children}</span>}

--- a/packages/ui/src/components/date-field.tsx
+++ b/packages/ui/src/components/date-field.tsx
@@ -23,9 +23,11 @@ type DateFieldProps = {
   name: string;
   label: string;
   defaultValue?: string | null;
+  /** For placement only — the field sizes itself to its segments. */
+  className?: string;
 };
 
-export function DateField({ name, label, defaultValue }: DateFieldProps) {
+export function DateField({ name, label, defaultValue, className }: DateFieldProps) {
   const parsedDefault = defaultValue ? parseDate(defaultValue) : undefined;
 
   return (
@@ -33,7 +35,7 @@ export function DateField({ name, label, defaultValue }: DateFieldProps) {
       name={name}
       defaultValue={parsedDefault}
       shouldForceLeadingZeros
-      className="flex flex-col gap-1.5"
+      className={cx("flex flex-col gap-1.5", className)}
     >
       <Label>{label}</Label>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ catalogs:
       version: 8.2.2
   icons:
     lucide-react:
-      specifier: ^1.33.0
-      version: 1.33.0
+      specifier: ^1.34.0
+      version: 1.34.0
   orm:
     '@libsql/client':
       specifier: 0.17.4
@@ -48,8 +48,8 @@ catalogs:
       version: 4.3.3
   types:
     '@types/node':
-      specifier: ^26.2.0
-      version: 26.2.0
+      specifier: ^26.4.0
+      version: 26.4.0
     '@types/react':
       specifier: ^19.2.18
       version: 19.2.18
@@ -66,7 +66,7 @@ importers:
         version: 7.0.2
       vite-plus:
         specifier: 0.3.0
-        version: 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+        version: 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
 
   apps/web:
     dependencies:
@@ -99,7 +99,7 @@ importers:
         version: 5.2.1
       lucide-react:
         specifier: catalog:icons
-        version: 1.33.0(react@19.2.8)
+        version: 1.34.0(react@19.2.8)
       react:
         specifier: catalog:react
         version: 19.2.8
@@ -158,7 +158,7 @@ importers:
         version: 0.17.4
       '@types/node':
         specifier: catalog:types
-        version: 26.2.0
+        version: 26.4.0
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -170,7 +170,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: catalog:types
-        version: 26.2.0
+        version: 26.4.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -187,7 +187,7 @@ importers:
         version: 1.0.0-beta.8(typescript@7.0.2)
       lucide-react:
         specifier: catalog:icons
-        version: 1.33.0(react@19.2.8)
+        version: 1.34.0(react@19.2.8)
       react:
         specifier: '*'
         version: 19.2.8
@@ -1570,6 +1570,9 @@ packages:
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
+
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
@@ -2588,8 +2591,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.33.0:
-    resolution: {integrity: sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==}
+  lucide-react@1.34.0:
+    resolution: {integrity: sha512-vnjGJNI7Htk5+oWW8gXGuaLgwgAb0T6/iZbBrp9JCfRFwdNWZ0YTm3eyxjOLgwN6r8iyAf3UA70zNmBRBNv7yg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -4087,6 +4090,10 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/node@26.4.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/qs@6.15.1': {}
 
   '@types/range-parser@1.2.7': {}
@@ -4175,28 +4182,28 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitest/browser-preview@4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)':
+  '@vitest/browser-preview@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.6(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)':
+  '@vitest/browser@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
       '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -4213,13 +4220,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -4773,7 +4780,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.33.0(react@19.2.8):
+  lucide-react@1.34.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 
@@ -4816,7 +4823,7 @@ snapshots:
 
   on-headers@1.1.0: {}
 
-  oxfmt@0.64.0(svelte@5.56.2)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))):
+  oxfmt@0.64.0(svelte@5.56.2)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -4840,7 +4847,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.64.0
       '@oxfmt/binding-win32-x64-msvc': 0.64.0
       svelte: 5.56.2
-      vite-plus: 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      vite-plus: 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -4851,7 +4858,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))):
+  oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.79.0
       '@oxlint/binding-android-arm64': 1.79.0
@@ -4873,7 +4880,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.79.0
       '@oxlint/binding-win32-x64-msvc': 1.79.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      vite-plus: 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
 
   p-map@7.0.6: {}
 
@@ -5180,24 +5187,24 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)):
+  vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)):
     dependencies:
       '@oxc-project/types': 0.146.0
       '@oxlint/plugins': 1.79.0
-      '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
-      '@vitest/browser-preview': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
+      '@vitest/browser-preview': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
       '@vitest/spy': 4.1.11
       '@vitest/utils': 4.1.11
       '@voidzero-dev/vite-plus-core': 0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)
-      oxfmt: 0.64.0(svelte@5.56.2)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)))
-      oxlint: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)))
+      oxfmt: 0.64.0(svelte@5.56.2)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)))
+      oxlint: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.2)(terser@5.48.0)(tsx@4.22.4)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.3.0
       '@voidzero-dev/vite-plus-darwin-x64': 0.3.0
@@ -5253,10 +5260,25 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
 
-  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)):
+  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.4.0
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.48.0
+      tsx: 4.22.4
+
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.11)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -5273,11 +5295,11 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
-      '@vitest/browser-preview': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
+      '@vitest/browser-preview': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4))(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalogs:
     "@cloudflare/vite-plugin": ^1.51.1
     wrangler: ^4.120.0
   icons:
-    lucide-react: ^1.33.0
+    lucide-react: ^1.34.0
   orm:
     "@libsql/client": 0.17.4
     drizzle-orm: 1.0.0-rc.4
@@ -38,6 +38,6 @@ catalogs:
     tailwind-merge: ^3.6.0
     "tailwindcss": ^4.3.3
   types:
-    "@types/node": ^26.2.0
+    "@types/node": ^26.4.0
     "@types/react": ^19.2.18
     "@types/react-dom": ^19.2.5


### PR DESCRIPTION
Außerhalb von `manager/_layout.tsx` gab es in den Manager-Seiten **keine einzige** responsive Klasse — überall hartes `p-8` und Tabellen ohne Rückfallebene. Entscheidung vorab: voll bedienbar ab 375px, **inklusive** Tipp- und Ergebnis-Erfassung.

## Gemeinsame Regeln

Über alle Seiten hinweg einheitlich:

- Formulare stapeln unter `sm:`, Spalten verschwinden ab `xs:` (480px) via `xs:table-cell hidden` — dasselbe Idiom, das die öffentliche Spielübersicht schon nutzt
- Das Seiten-Padding sitzt jetzt **einmal** im Scroll-Container des Layouts (`px-2 py-6 sm:p-8`) statt in 15 Routen-Dateien
- Spaltenvorlagen richten sich nach dem Inhalt, nicht nach gleichen Anteilen

**Die wichtigste Erkenntnis:** ab `md:` zieht die Sidebar 208px vom Viewport ab. Ein `md:grid-cols-4` ist dort fast immer zu früh — beim Spiel-Formular liegt die vierspaltige Stufe deshalb hergeleitet auf `lg:` (4 × 137px Mindestbreite des Datumsfelds + Gaps ⇒ ~916px Viewport).

## Was pro Seite passiert ist

| Seite | Problem | Lösung |
|---|---|---|
| **Spiele** | 4 Spalten in 259px, Combobox-Eingaben **21px** breit, Kalender-Button außerhalb seiner Spalte | Formular 1 → 2 → 4 Spalten; Datum + Liga ausgeblendet, kommen als Meta-Zeile unter der Paarung zurück |
| **Turnier-Übersicht** | drei Switches nebeneinander brauchen 410px, „Abgeschlossen" lief über den Rand | gestapelt unter `sm:` |
| **Spieler** | `table-fixed`-Breiten (224+112+48) überschreiten 375px | E-Mail und Rolle unter `xs:` raus — die Adresse steht im Bearbeiten-Dialog, wo eine Änderung ohnehin landet |
| **Zusatzfragen** | Antwortfeld unter 110px, obwohl man die Antwort zum Bewerten lesen muss | Antwort in eigene Zeile über die volle Breite; Labels im Small-State, Spaltenköpfe auf dem Desktop (die es vorher **gar nicht** gab) |
| **Turniere / Regelwerke** | Namensspalte auf 55px gequetscht und **über** den Nachbartext gelaufen | die verdrängende Spalte fällt unter `xs:` weg |
| **Tipps** | Joker-Checkbox 20px Trefferfläche | auf 36×44 vergrößert, Optik und Layout unverändert |
| **Runden-Navigator** | 28px Pfeile | 40px unter `sm:` |

Der Read-Only-Zustand abgeschlossener Turniere brauchte eigene Arbeit: ohne die Input-Rahmen des editierbaren Zustands gruppierte nichts die Zeilen, und ein Label neben einer dreizeiligen Antwort schwebte in deren Mitte.

## Ohne Änderung, aber geprüft

Ergebnisse, Teams, Ligen, Import und alle Stammdaten-Dialoge — gemessen, nicht angenommen. Bei Teams und Ligen schneidet **keiner** von 40 bzw. 17 Namen ab.

## Design-Review

Per Projekt-Konvention lief `emil-design-eng` über die interaktiven Änderungen. Ergebnis: Switch und Checkbox liefen auf Tailwinds Standard-Kurve statt auf dem projekteigenen `--ease-out`, und der Checkbox fehlte das Press-Feedback, das der Button hat — beides korrigiert.

## Bewusst nicht enthalten

- **Die 13 verbleibenden 28px-Icon-Buttons.** Eine globale Vergrößerung ist nicht machbar: gemessen stehen im öffentlichen Header Farbschema-Umschalter und Benutzer-Button **4px** auseinander, im Manager die 17 „entfernen"-Buttons **17px**. Erweiterte Flächen würden überlappen, und eine falsche Aktion ist schlimmer als ein verfehlter Tap. 28px erfüllt WCAG 2.5.8 (24px Minimum).
- **Ein globales `prefers-reduced-motion`.** Fehlt im ganzen Projekt und beträfe auch den öffentlichen Bereich — eigenes Thema.

Dazu zwei Commits, die inhaltlich nicht zum Thema gehören, aber mitreiten, um einen separaten PR zu sparen: die Zed-Einstellung gegen den doppelten TypeScript-Server und ein Bump von `lucide-react` und `@types/node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)