### PR TITLE
fix(web): Trust the proxy so actions survive the origin check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.4.1
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.4.0...v1.4.1)
+
+### 🩹 Fixes
+
+- **web:** Trust the proxy so actions survive the origin check ([f640a40](https://github.com/haus23/tipprunde/commit/f640a40))
+
 ## v1.4.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.3.0...v1.4.0)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@libsql/client": "catalog:orm",
     "@react-router/node": "^8.3.1",
+    "@remix-run/node-fetch-server": "^0.14.1",
     "@tipprunde/db": "workspace:*",
     "@tipprunde/domain": "workspace:*",
     "@tipprunde/theme": "workspace:*",

--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -2,9 +2,9 @@ import { createServer } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 
-import { createRequestListener } from "@react-router/node";
+import { createRequestListener } from "@remix-run/node-fetch-server";
 import compressionMiddleware from "compression";
-import { RouterContextProvider } from "react-router";
+import { createRequestHandler, RouterContextProvider } from "react-router";
 import sirv from "sirv";
 
 type NodeMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
@@ -32,11 +32,20 @@ const serveAssets = sirv(CLIENT_ASSETS_PATH, {
   immutable: true,
 });
 
-const handleRequest = createRequestListener({
-  build,
-  mode: process.env.NODE_ENV,
-  getLoadContext: () => new RouterContextProvider(),
-});
+// Built here rather than with `@react-router/node`'s wrapper, which is the
+// same three lines but passes no listener options — and `trustProxy` is the
+// one we need. Without it the request URL takes its protocol from the socket,
+// which behind Railway's TLS-terminating proxy is plain http. React Router
+// then compares that against the browser's `Origin: https://…`, reads the
+// mismatch as a CSRF attempt and answers every action with 400. Railway
+// overwrites the `X-Forwarded-*` headers, so trusting them is sound; locally
+// nothing sends them and the behaviour is unchanged.
+const requestHandler = createRequestHandler(build, process.env.NODE_ENV);
+
+const handleRequest = createRequestListener(
+  (request) => requestHandler(request, new RouterContextProvider()),
+  { trustProxy: true },
+);
 
 // @types/compression assumes an Express req/res; the middleware itself only
 // touches plain Node http properties at runtime, so this is a types-only cast.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@react-router/node':
         specifier: ^8.3.1
         version: 8.3.1(react-router@8.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
+      '@remix-run/node-fetch-server':
+        specifier: ^0.14.1
+        version: 0.14.1
       '@tipprunde/db':
         specifier: workspace:*
         version: link:../../packages/db


### PR DESCRIPTION
**Auf dem Live-Build antwortet derzeit jede Action mit 400.** Login, Logout und sämtliche Manager-Mutationen sind betroffen. Der Farbumschalter *sieht* aus als funktioniere er, weil der Toggle das DOM-Attribut sofort setzt — das Cookie kommt aber nie zurück, die Wahl übersteht kein Neuladen.

## Ursache

React Routers CSRF-Wächter vergleicht den `Origin`-Header mit `new URL(request.url).origin`. Der Node-Adapter leitet dessen Protokoll aus dem Socket ab, und hinter der TLS-terminierenden Kette vor uns — Cloudflare, dann Railway — ist der unverschlüsselt. Also trifft `https://next.runde.tips` auf `http://next.runde.tips`, und der Wächter liest die Schema-Abweichung als Angriff.

**Ausgelöst hat es unser eigener Bump von gestern.** Den Wächter gibt es seit 8.0.0, aber er verglich bis 8.3.0 nur Hosts:

```js
// 8.3.0
let host = new URL(request.url).host;
if (originDomain && originDomain !== host) { throw }

// 8.3.1
originMatchesRequest = originUrl.origin === requestUrl.origin
```

Host gegen Host passte, das falsche Schema fiel nicht auf. Origin gegen Origin fällt es auf. Upstream nennt es beim Namen — [„Validate Schemeful Action Origins", remix-run/react-router#15419](https://github.com/remix-run/react-router/pull/15419), gemergt am 20.08., ausgeliefert in 8.3.1 am 28.08. Das ist **beabsichtigte Verschärfung**, kein Bug; auf ein Folge-Release zu warten hilft also nicht.

Das erklärt auch die Zeitachse: Datenänderungen am 26.08. liefen noch unter 8.3.0, der Login auf der PR-14-Umgebung ebenfalls.

## Der Fix

`trustProxy` am Listener, damit das Protokoll aus `X-Forwarded-Proto` kommt. Damit sagt `request.url` https — und zwar nicht nur für den Wächter, sondern für alles andere, was es liest: Redirects, absolute URLs.

Die Alternative wäre `allowedActionOrigins` in der Config gewesen. Bewusst nicht gewählt: unser Fall ist kein fremder Origin, den man zulassen möchte, sondern ein **falsch gebildetes `request.url`**. Den Wächter stillzulegen hätte das Symptom versteckt und die falsche URL gelassen.

Die Option existiert nur am Listener aus `@remix-run/node-fetch-server`. Der Wrapper von `@react-router/node` sind dieselben drei Zeilen, reicht aber keine Optionen durch — deshalb wird der Listener jetzt hier gebaut und das Paket eine direkte Abhängigkeit.

`trustProxy` heißt, den `X-Forwarded-*`-Headern zu glauben. Das ist hier richtig, weil die Proxies vor uns sie überschreiben; lokal sendet sie niemand und das Verhalten bleibt unverändert.

## Prüfung

Gegen den echten Production-Build lokal, mit demselben POST und nur variierenden Headern:

| Fall | vorher | nachher |
|---|---|---|
| `Origin: http://…`, kein Proxy-Header | 200 | **200** |
| `Origin: https://…`, **kein** `X-Forwarded-Proto` | 400 | **400** — echter Mismatch, korrekt abgelehnt |
| `Origin: https://…` + `X-Forwarded-Proto: https` ← Railway | 400 | **200**, mit `Set-Cookie` |

Zusätzlich am Live-Build von außen belegt: POST mit `Origin` → 400, derselbe POST ohne `Origin` → 200. Genau das Verhalten, das der Wächter zeigt.

## Nachbemerkung

Meine Prüfung beim Dependency-Update hat das nicht gefunden — typecheck und lokale Smoke-Tests können es nicht finden, weil der Fall ohne Proxy nicht auftritt. Ein Framework-Patch kann Sicherheitsverhalten verschärfen; das steht im Changelog, nicht im lokalen Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)