### PR TITLE
fix(web): Let an empty email actually clear the address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.4.2
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.4.1...v1.4.2)
+
+### 🩹 Fixes
+
+- **web:** Let an empty email actually clear the address ([e860ee7](https://github.com/haus23/tipprunde/commit/e860ee7))
+
+### 🏡 Chore
+
+- **web:** Drop the unused accent constant from the login mail ([944a673](https://github.com/haus23/tipprunde/commit/944a673))
+
 ## v1.4.1
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.4.0...v1.4.1)

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -25,10 +25,15 @@ const spielerSchema = createInsertSchema(users, {
   id: v.optional(v.pipe(v.string(), v.toNumber(), v.integer())),
   name: (schema) => v.pipe(schema, v.trim(), v.nonEmpty("Name ist erforderlich")),
   slug: (schema) => v.pipe(schema, v.trim(), v.nonEmpty("Kennung ist erforderlich")),
+  // Empty has to land as null, not undefined: Drizzle reads undefined in
+  // `.set()` as "leave this column alone", so clearing an address silently
+  // kept the old one. Every other optional field in the manager is built by
+  // hand with `|| null` — this one goes through a schema, which is how it
+  // came to differ.
   email: v.pipe(
     v.optional(v.string()),
-    v.transform((v) => v?.trim() || undefined),
-    v.optional(v.pipe(v.string(), v.email("Keine gültige E-Mail-Adresse"))),
+    v.transform((value) => value?.trim() || null),
+    v.nullable(v.pipe(v.string(), v.email("Keine gültige E-Mail-Adresse"))),
   ),
   role: v.picklist(["user", "manager", "admin"]),
 });

--- a/apps/web/app/routes/public/_login-mail.server.ts
+++ b/apps/web/app/routes/public/_login-mail.server.ts
@@ -10,7 +10,6 @@ import type { Mail } from "#/lib/mail.server.ts";
  * below are their sRGB equivalents, kept in sync by hand.
  */
 
-const ACCENT = "#f76b15"; // orange9
 const ACCENT_TEXT = "#cc4e00"; // orange11 — accent on light, for text
 const SAND_1 = "#fdfdfc";
 const SAND_2 = "#f9f9f8";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Die E-Mail-Adresse eines Spielers zu leeren — um ihn vom Login auszuschließen — hatte keine Wirkung. Der alte Wert blieb stehen.

## Ursache

Das Schema bildete Leer auf **`undefined`** ab:

```js
email: v.pipe(
  v.optional(v.string()),
  v.transform((v) => v?.trim() || undefined),   // ← "" wird undefined
  v.optional(v.pipe(v.string(), v.email(...))),
),
```

Drizzle liest `undefined` in `.set()` als „diese Spalte nicht anfassen". Die Spalte wurde also nie geschrieben. Beim **Anlegen** fiel es nicht auf, weil eine weggelassene Spalte ohnehin `NULL` wird — nur beim Aktualisieren blieb der alte Wert.

Leer landet jetzt als `null`, und das ist ein ausdrücklicher Schreibvorgang.

## Betrifft es weitere Felder? Nein.

Alle sechs `.set()`-Aufrufe auf Tabellen mit optionalen Spalten durchgesehen:

| Stelle | Felder | Muster |
|---|---|---|
| `spiele.tsx` | `date`, `leagueId`, `hometeamId`, `awayteamId` | `\|\| null` ✓ |
| `ergebnisse.tsx` | `result` | `\|\| null` ✓ |
| `zusatzfragen.tsx` | `answer` | `\|\| null` ✓ |
| `turniere.tsx` | `rulesetId` | im Update bewusst nie angefasst ✓ |
| `championship/index.tsx` | Flags | Booleans ✓ |
| **`spieler.tsx`** | **`email`** | **war `\|\| undefined`** ✗ |

Der Grund für den Ausreißer: `email` ist das **einzige** Optionalfeld, dessen Umwandlung in einem Valibot-Schema steckt. Überall sonst ist sie handgeschrieben — und dort steht `null`. Eine Stilabweichung, kein Denkfehler im Muster.

## Prüfung

Über die echte Manager-Oberfläche gegen die Dev-Datenbank: Adresse geleert, gespeichert, die Zeile kommt mit echtem SQL-`NULL` zurück (`typeof(email) = 'null'`). Der Testwert wurde danach wiederhergestellt.

## Nachtrag zum eigentlichen Ziel

Der Fix verhindert **neue** Logins — `findUserByEmail` findet den Nutzer nicht mehr. Eine **laufende Sitzung** beendet er nicht: die liegen in der `sessions`-Tabelle mit eigenem Ablauf, bei `SESSION_DURATION_REMEMBER` bis zu 30 Tage. Wer gerade mit „angemeldet bleiben" eingeloggt ist, bleibt es so lange.

Falls der Ausschluss sofort greifen soll, wäre der ergänzende Schritt, beim Leeren der Adresse auch die Sessions des Nutzers zu löschen — die Tabelle ist ja genau dafür serverseitig widerrufbar gebaut. Das ist eine Design-Entscheidung und bewusst nicht Teil dieses Fixes.

Dazu ein zweiter, unabhängiger Commit: eine ungenutzte Farbkonstante im Login-Mail-Template fällt weg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)