### PR TITLE
feat(web): End a player's sessions when their address changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.5.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.4.2...v1.5.0)
+
+### 🚀 Enhancements
+
+- **web:** End a player's sessions when their address changes ([cd2be18](https://github.com/haus23/tipprunde/commit/cd2be18))
+- **web:** Say that changing an address ends sessions ([0b00f3c](https://github.com/haus23/tipprunde/commit/0b00f3c))
+
 ## v1.4.2
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.4.1...v1.4.2)

--- a/apps/web/app/components/spieler-dialog.tsx
+++ b/apps/web/app/components/spieler-dialog.tsx
@@ -108,6 +108,13 @@ function SpielerForm({ defaultValues, onClose, onSuccess }: SpielerFormProps) {
         type="email"
         defaultValue={defaultValues?.email ?? ""}
         label="E-Mail"
+        // Only on edit: creating a player has no sessions to end. Worth saying
+        // out loud, because the effect lands on someone else's screen.
+        description={
+          defaultValues
+            ? "Ändern oder Leeren beendet bestehende Anmeldungen dieses Spielers."
+            : undefined
+        }
       />
 
       <Select

--- a/apps/web/app/lib/session.server.ts
+++ b/apps/web/app/lib/session.server.ts
@@ -1,5 +1,5 @@
 import { sessions } from "@tipprunde/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { createCookieSessionStorage } from "react-router";
 
 import type { User } from "./context";
@@ -78,6 +78,27 @@ export async function createSession(userId: number, rememberMe: boolean): Promis
 /** Cookie lifetime mirrors the DB session's — a session cookie unless remembered. */
 export function sessionCookieMaxAge(rememberMe: boolean): number | undefined {
   return rememberMe ? SESSION_DURATION_REMEMBER : undefined;
+}
+
+/**
+ * Ends every session a user holds, optionally sparing one.
+ *
+ * The address is the only credential — the login code goes there — so changing
+ * or clearing it has to cut off whoever held the old one. Without this, a
+ * "remember me" session outlives the change by up to 30 days.
+ *
+ * `keepSessionId` spares the caller's own session, so an admin correcting their
+ * own address does not log themselves out mid-edit. Editing someone else, that
+ * id belongs to a different user and the clause simply never matches.
+ */
+export async function revokeUserSessions(userId: number, keepSessionId?: string) {
+  await db
+    .delete(sessions)
+    .where(
+      keepSessionId
+        ? and(eq(sessions.userId, userId), ne(sessions.id, keepSessionId))
+        : eq(sessions.userId, userId),
+    );
 }
 
 export async function deleteSession(sessionId: string) {

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -8,6 +8,7 @@ import * as v from "valibot";
 
 import { SpielerDialog } from "#/components/spieler-dialog.tsx";
 import { db } from "#/lib/db.server.ts";
+import { getSessionFromRequest, revokeUserSessions } from "#/lib/session.server.ts";
 
 import type { Route } from "./+types/spieler";
 
@@ -72,7 +73,34 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   if (intent === "update" && id) {
+    const existing = await db.query.users.findFirst({ where: { id } });
+    if (!existing) return null;
+
+    // Both columns are unique in the database. Without this the constraint
+    // decides, which surfaces as an unhandled error instead of a message on
+    // the field. Excluding the row itself, or saving a player unchanged would
+    // collide with their own values.
+    const [slugConflict, emailConflict] = await Promise.all([
+      db.query.users.findFirst({ where: { slug: values.slug, id: { ne: id } } }),
+      values.email
+        ? db.query.users.findFirst({ where: { email: values.email, id: { ne: id } } })
+        : Promise.resolve(null),
+    ]);
+    const conflicts: Record<string, string[]> = {};
+    if (slugConflict) conflicts.slug = ["Diese Kennung ist bereits vergeben"];
+    if (emailConflict) conflicts.email = ["Diese E-Mail ist bereits vergeben"];
+    if (Object.keys(conflicts).length) return { errors: conflicts };
+
     const [user] = await db.update(users).set(values).where(eq(users.id, id)).returning();
+
+    // Only the address is a credential; name, slug and role are not. A role
+    // change needs no help here either — getSessionUser reads it fresh from
+    // the database on every request, so a demotion already takes effect at once.
+    if (existing.email !== values.email) {
+      const session = await getSessionFromRequest(request);
+      await revokeUserSessions(id, session.get("sessionId"));
+    }
+
     return { user };
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Nachtrag zu v1.4.2. Das Leeren einer Adresse verhindert **neue** Anmeldungen, ließ eine **laufende** Sitzung aber bis zu 30 Tage weiterleben — jemanden auszusperren sperrte ihn also nicht wirklich aus. Beim *Ändern* der Adresse, um ein Konto an eine andere Person zu übergeben, dieselbe Lücke.

## Warum nur die Adresse

`name` und `slug` sind Bezeichner. Die Rolle braucht die Logik ebenfalls nicht: `getSessionUser` liest sie bei **jedem** Request frisch über die Relation, eine Herabstufung wirkt also ohnehin sofort. Die Adresse ist das einzige Feld, das bestimmt, wer sich eine neue Sitzung holen kann — der TOTP-Code geht dorthin.

Deshalb löst **nur eine tatsächliche Änderung** der Adresse den Widerruf aus. Bei jedem Speichern zu feuern würde Leute über eine korrigierte Schreibweise ihres Namens abmelden.

## Die eigene Sitzung bleibt

Korrigiert ein Admin seine **eigene** Adresse, würde er sich mitten in der Aktion selbst rauswerfen. Die aufrufende Sitzung wird deshalb verschont:

```sql
delete from sessions where user_id = ? and id != <aktuelle Sitzung>
```

Bearbeitet er jemand anderen, gehört diese id einem anderen Nutzer und die Bedingung greift nie — dort fallen alle Sitzungen des Betroffenen.

## Die Lücke nebenan

`slug` und `email` sind in der Datenbank `unique()`, geprüft wurde bisher aber **nur beim Anlegen**. Wer beim Bearbeiten einen bereits vergebenen Wert einträgt, lief in den Constraint — also ein unbehandelter Fehler statt einer Meldung am Feld. Die Prüfung läuft jetzt auch im Update, unter Ausschluss der eigenen Zeile: sonst kollidiert ein unverändert gespeicherter Spieler mit seinen eigenen Werten.

## Prüfung

Über HTTP gegen die Dev-Datenbank, mit eigens angelegten Testnutzern und einer echten Sitzung:

| Fall | Erwartung | Ergebnis |
|---|---|---|
| Adresse geändert | Sitzung des Spielers weg | ✅ |
| Kennung auf eine vergebene gesetzt | Feldmeldung, **kein** Schreibvorgang | ✅ |
| Adresse auf eine vergebene gesetzt | Feldmeldung, **kein** Schreibvorgang | ✅ |
| Nur den Namen geändert | Sitzung überlebt | ✅ |
| Admin ändert die eigene Adresse | eigene Sitzung überlebt | ✅ |

Keiner der Konfliktfälle liefert noch einen 500er, und die Daten blieben in beiden unverändert. Testnutzer wurden danach gelöscht.

## Anmerkung

Der zweite Commit ergänzt einen Hinweis im Dialog. Die Wirkung landet auf dem Bildschirm einer anderen Person — das sollte dort stehen und nicht erst durch einen verwirrten Anruf auffallen. Nur beim Bearbeiten sichtbar; beim Anlegen gibt es keine Sitzungen zu beenden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)