### PR TITLE
Observability: auth events, error mails, alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v1.6.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.5.0...v1.6.0)
+
+### 🚀 Enhancements
+
+- **db,web:** Record what happens around signing in ([56cdf08](https://github.com/haus23/tipprunde/commit/56cdf08))
+- **web:** Mail unhandled server errors ([cc37638](https://github.com/haus23/tipprunde/commit/cc37638))
+- **web:** Alert when failed sign-ins pile up ([fd0dab6](https://github.com/haus23/tipprunde/commit/fd0dab6))
+- **web:** Add the security overview ([85d2904](https://github.com/haus23/tipprunde/commit/85d2904))
+
+### 💅 Refactors
+
+- **web:** Name the colouring list for what it means ([3cae2ad](https://github.com/haus23/tipprunde/commit/3cae2ad))
+
+### 📖 Documentation
+
+- Record the observability decisions ([78a7e86](https://github.com/haus23/tipprunde/commit/78a7e86))
+- Note that the chat moves the dev server too ([21a95bd](https://github.com/haus23/tipprunde/commit/21a95bd))
+
 ## v1.5.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.4.2...v1.5.0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ is. Superseded, never quietly rewritten:**
 - `04-app-merge.md` — How the TanStack Start app merged into the RR8 app (done 2026-08-09)
 - `05-championship-scope.md` — Championship as a URL dimension; Archiv and current season share route files
 - `06-verlauf-bump-chart.md` — Punkteverlauf as a bump chart, and the measurement that picked that form
+- `07-observability.md` — Auth-event log, error and alert mails; why no Sentry, no IPs, and no rate limit yet
 
 ## Skills
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -122,6 +122,7 @@ Shared docs are in the root `docs/` folder.
 - `04-app-merge.md` — How this app absorbed the separate web app (why things look the way they do)
 - `05-championship-scope.md` — Championship as a URL dimension, shared route files for Archiv + current season
 - `06-verlauf-bump-chart.md` — Punkteverlauf as a bump chart, hand-rolled SVG
+- `07-observability.md` — Auth-event log, error and alert mails; why no Sentry, no IPs, and no rate limit yet
 
 ## Environment variables
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -132,6 +132,9 @@ mail and code settings, not just the DB:
 `RESEND_API_KEY`, `FROM_EMAIL`, `TOTP_EXPIRES_IN`, `TOTP_MAX_ATTEMPTS`,
 `SESSION_DURATION_DEFAULT`, `SESSION_DURATION_REMEMBER`
 
+`ALERT_EMAIL` is production-only — it is read by `server/app.ts`, which
+`react-router dev` never runs. Errors in development go to the console.
+
 In production they are set per Railway environment. The first five are
 secrets and never belong in the repo. See `docs/deployment.md`.
 

--- a/apps/web/app/lib/auth-events.server.ts
+++ b/apps/web/app/lib/auth-events.server.ts
@@ -1,0 +1,65 @@
+import { type AuthEventType, authEvents } from "@tipprunde/db/schema";
+import { lt } from "drizzle-orm";
+
+import { db } from "./db.server";
+
+const RETENTION_DAYS = 90;
+const PRUNE_INTERVAL = 24 * 60 * 60 * 1000;
+
+/**
+ * In memory, so it resets on every deploy — which only means one extra prune
+ * after a release. Not worth a table of its own.
+ */
+let lastPrune = 0;
+
+type AuthEvent = {
+  type: AuthEventType;
+  userId?: number | null;
+  /** The address that was used, including one that matched no user. */
+  email?: string | null;
+  detail?: string | null;
+};
+
+/**
+ * Records one authentication event.
+ *
+ * Never throws: this is a log, and a log that can break the login it observes
+ * is worse than no log at all. A failure here goes to stderr and nowhere else.
+ */
+export async function logAuthEvent({ type, userId, email, detail }: AuthEvent): Promise<void> {
+  try {
+    await db.insert(authEvents).values({
+      type,
+      // Written here rather than left to the column default: SQLite's
+      // CURRENT_TIMESTAMP writes "2026-09-04 12:52:06", which does not compare
+      // correctly against an ISO string. Every read of this table is a
+      // comparison — the prune cutoff, the alert window, the newest-first
+      // order — so all rows have to be in one format, and that format is the
+      // one the rest of the app writes.
+      createdAt: new Date().toISOString(),
+      userId: userId ?? null,
+      email: email ?? null,
+      detail: detail ?? null,
+    });
+    await pruneAuthEvents();
+  } catch (err) {
+    console.error("[auth-events] insert failed:", err);
+  }
+}
+
+/**
+ * Drops events past the retention window.
+ *
+ * Piggybacks on writing an event rather than running on a schedule: the table
+ * only grows when someone signs in, so the moment a row is added is exactly
+ * when a prune is worth considering. The interval keeps that to one DELETE a
+ * day instead of one per login.
+ */
+async function pruneAuthEvents(): Promise<void> {
+  const now = Date.now();
+  if (now - lastPrune < PRUNE_INTERVAL) return;
+  lastPrune = now;
+
+  const cutoff = new Date(now - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  await db.delete(authEvents).where(lt(authEvents.createdAt, cutoff));
+}

--- a/apps/web/app/lib/auth-events.server.ts
+++ b/apps/web/app/lib/auth-events.server.ts
@@ -2,9 +2,32 @@ import { type AuthEventType, authEvents } from "@tipprunde/db/schema";
 import { lt } from "drizzle-orm";
 
 import { db } from "./db.server";
+import { opsMail, sendMail } from "./mail.server";
+
+const ALERT_EMAIL = process.env["ALERT_EMAIL"];
 
 const RETENTION_DAYS = 90;
 const PRUNE_INTERVAL = 24 * 60 * 60 * 1000;
+
+/**
+ * More than five failed attempts within ten minutes is the point where this
+ * stops looking like someone mistyping their address. Set from the shape of
+ * this site, not from a standard: a round has around twenty players, and a
+ * legitimate person fails twice and then asks Micha.
+ */
+const ALERT_THRESHOLD = 5;
+const ALERT_WINDOW = 10 * 60 * 1000;
+/** Silence after an alert. An attack that keeps running is still one attack. */
+const ALERT_COOLDOWN = 60 * 60 * 1000;
+
+/**
+ * What counts as a failed attempt. An expired code does not: it means someone
+ * asked for one and got to it too late, which is nobody attacking anything.
+ * A technical failure does not either — that is a fault, not an attempt.
+ */
+const FAILURE_TYPES: AuthEventType[] = ["unknown_email", "code_invalid", "code_max_attempts"];
+
+let lastAlert = 0;
 
 /**
  * In memory, so it resets on every deploy — which only means one extra prune
@@ -45,6 +68,16 @@ export async function logAuthEvent({ type, userId, email, detail }: AuthEvent): 
   } catch (err) {
     console.error("[auth-events] insert failed:", err);
   }
+
+  // Separate, so a mail that will not go out cannot be mistaken for a log that
+  // did not get written.
+  if (FAILURE_TYPES.includes(type)) {
+    try {
+      await checkForAttack();
+    } catch (err) {
+      console.error("[auth-events] alert failed:", err);
+    }
+  }
 }
 
 /**
@@ -62,4 +95,56 @@ async function pruneAuthEvents(): Promise<void> {
 
   const cutoff = new Date(now - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
   await db.delete(authEvents).where(lt(authEvents.createdAt, cutoff));
+}
+
+/**
+ * Mails when failed attempts pile up.
+ *
+ * Counted across the whole site rather than per address: without IP addresses
+ * the address is the only handle there is, and someone working through a list
+ * of guesses would stay under a per-address threshold forever. With this few
+ * users, six failures inside ten minutes is unusual whoever they belong to.
+ */
+async function checkForAttack(): Promise<void> {
+  const now = Date.now();
+  if (now - lastAlert < ALERT_COOLDOWN) return;
+
+  const since = new Date(now - ALERT_WINDOW).toISOString();
+  const recent = await db.query.authEvents.findMany({
+    where: { type: { in: FAILURE_TYPES }, createdAt: { gte: since } },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (recent.length <= ALERT_THRESHOLD) return;
+  lastAlert = now;
+
+  if (!ALERT_EMAIL) {
+    console.warn(`[auth-events] ${recent.length} failed attempts, but ALERT_EMAIL is not set.`);
+    return;
+  }
+
+  const labels: Record<string, string> = {
+    unknown_email: "unbekannte Adresse",
+    code_invalid: "falscher Code",
+    code_max_attempts: "zu viele Fehlversuche",
+  };
+
+  const body = [
+    `${recent.length} fehlgeschlagene Anmeldeversuche in den letzten ${ALERT_WINDOW / 60000} Minuten.`,
+    "",
+    ...recent.map((event) => {
+      const time = new Date(event.createdAt).toLocaleTimeString("de-DE", {
+        timeZone: "Europe/Berlin",
+      });
+      return `${time}  ${labels[event.type] ?? event.type}  ${event.email ?? "—"}`;
+    }),
+    "",
+    "Alle Ereignisse im Manager unter /manager/sicherheit.",
+  ].join("\n");
+
+  await sendMail({
+    to: ALERT_EMAIL,
+    subject: `[runde.tips] ${recent.length} fehlgeschlagene Anmeldeversuche`,
+    ...opsMail(body),
+  });
 }

--- a/apps/web/app/lib/auth-events.server.ts
+++ b/apps/web/app/lib/auth-events.server.ts
@@ -148,3 +148,34 @@ async function checkForAttack(): Promise<void> {
     ...opsMail(body),
   });
 }
+
+/**
+ * The security overview's data. Capped rather than paged: the point of the
+ * page is "what happened lately", and a window that reaches back further than
+ * anyone scrolls is not worth a pagination control.
+ */
+export async function getAuthEvents(limit = 200) {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const [events, lastDay, total] = await Promise.all([
+    db.query.authEvents.findMany({
+      orderBy: { createdAt: "desc" },
+      limit,
+      with: { user: { columns: { name: true } } },
+    }),
+    db.query.authEvents.findMany({
+      where: { createdAt: { gte: since } },
+      columns: { type: true },
+    }),
+    db.$count(authEvents),
+  ]);
+
+  return {
+    events,
+    total,
+    limit,
+    logins: lastDay.filter((e) => e.type === "login_succeeded").length,
+    failures: lastDay.filter((e) => FAILURE_TYPES.includes(e.type)).length,
+    retentionDays: RETENTION_DAYS,
+  };
+}

--- a/apps/web/app/lib/error-report.server.ts
+++ b/apps/web/app/lib/error-report.server.ts
@@ -1,6 +1,6 @@
 import { isRouteErrorResponse } from "react-router";
 
-import { sendMail } from "./mail.server.ts";
+import { opsMail, sendMail } from "./mail.server.ts";
 
 /**
  * Mails unhandled server errors to whoever runs the site.
@@ -58,10 +58,6 @@ function shouldSend(key: string): boolean {
   return true;
 }
 
-function escapeHtml(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
 export function reportServerError(error: unknown, request: Request): void {
   // A visitor navigating away mid-request aborts it. Nothing is wrong.
   if (request.signal.aborted) return;
@@ -107,7 +103,6 @@ export function reportServerError(error: unknown, request: Request): void {
   void sendMail({
     to: ALERT_EMAIL,
     subject: `[runde.tips] ${message.slice(0, 120)}`,
-    html: `<pre style="font-family:ui-monospace,Menlo,Consolas,monospace; font-size:13px; white-space:pre-wrap;">${escapeHtml(body)}</pre>`,
-    text: body,
+    ...opsMail(body),
   }).catch((err) => console.error("[error-report] mail failed:", err));
 }

--- a/apps/web/app/lib/error-report.server.ts
+++ b/apps/web/app/lib/error-report.server.ts
@@ -1,0 +1,113 @@
+import { isRouteErrorResponse } from "react-router";
+
+import { sendMail } from "./mail.server.ts";
+
+/**
+ * Mails unhandled server errors to whoever runs the site.
+ *
+ * Imported from `server/app.ts`, which Node runs directly with type stripping
+ * — so this file and everything it reaches must stay free of JSX, `import.meta.env`
+ * and anything else only Vite understands. Relative imports need their file
+ * extension here for the same reason — Node's resolver does not guess it, and
+ * the rest of `lib/` gets away without one only because Vite resolves it.
+ *
+ * Until now nobody found out about a server error unless a user mentioned it.
+ * The error page says "Bitte versuche es später noch einmal", which asks for
+ * patience and offers no way to report anything.
+ */
+
+const ALERT_EMAIL = process.env["ALERT_EMAIL"];
+
+/** One mail per distinct error per hour, and never more than ten in an hour. */
+const COOLDOWN = 60 * 60 * 1000;
+const MAX_PER_HOUR = 10;
+
+const lastSent = new Map<string, number>();
+let windowStart = 0;
+let sentInWindow = 0;
+
+/**
+ * Groups repeats of the same fault. The message alone is too coarse — two
+ * different routes failing on "Cannot read properties of undefined" are two
+ * problems — so the innermost stack frame comes along.
+ */
+function fingerprint(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const frame = error.stack?.split("\n")[1]?.trim() ?? "";
+  return `${error.name}: ${error.message} @ ${frame}`;
+}
+
+function shouldSend(key: string): boolean {
+  const now = Date.now();
+
+  if (now - windowStart > COOLDOWN) {
+    windowStart = now;
+    sentInWindow = 0;
+    // The cooldown and the window are the same length, so nothing in here can
+    // still be blocking once the window rolls over.
+    lastSent.clear();
+  }
+
+  if (sentInWindow >= MAX_PER_HOUR) return false;
+
+  const previous = lastSent.get(key);
+  if (previous !== undefined && now - previous < COOLDOWN) return false;
+
+  lastSent.set(key, now);
+  sentInWindow += 1;
+  return true;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function reportServerError(error: unknown, request: Request): void {
+  // A visitor navigating away mid-request aborts it. Nothing is wrong.
+  if (request.signal.aborted) return;
+
+  // Route error responses are the app answering properly — a 404 for a
+  // championship that does not exist is not a fault. A 5xx one is.
+  if (isRouteErrorResponse(error) && error.status < 500) return;
+
+  // An `ErrorResponse` carries the error that caused it on a property its
+  // public type does not declare. React Router's own default handler unwraps it
+  // the same way; without that, a 500 would report as "[object Object]".
+  const unwrapped = isRouteErrorResponse(error)
+    ? ((error as { error?: unknown }).error ??
+      new Error(`${error.status} ${error.statusText}: ${String(error.data)}`))
+    : error;
+
+  console.error(unwrapped);
+
+  if (!ALERT_EMAIL) {
+    console.warn("[error-report] ALERT_EMAIL is not set — no mail sent.");
+    return;
+  }
+
+  if (!shouldSend(fingerprint(unwrapped))) return;
+
+  const url = new URL(request.url);
+  const message =
+    unwrapped instanceof Error ? `${unwrapped.name}: ${unwrapped.message}` : String(unwrapped);
+  const stack = unwrapped instanceof Error ? (unwrapped.stack ?? "") : "";
+
+  const body = [
+    message,
+    "",
+    `${request.method} ${url.pathname}${url.search}`,
+    new Date().toLocaleString("de-DE", { timeZone: "Europe/Berlin" }),
+    "",
+    stack,
+  ].join("\n");
+
+  // Not awaited: the request is already on its way to an error page, and a
+  // slow mail must not hold it up. A failure here is the one place left with
+  // nowhere to report to, so it goes to stderr.
+  void sendMail({
+    to: ALERT_EMAIL,
+    subject: `[runde.tips] ${message.slice(0, 120)}`,
+    html: `<pre style="font-family:ui-monospace,Menlo,Consolas,monospace; font-size:13px; white-space:pre-wrap;">${escapeHtml(body)}</pre>`,
+    text: body,
+  }).catch((err) => console.error("[error-report] mail failed:", err));
+}

--- a/apps/web/app/lib/mail.server.ts
+++ b/apps/web/app/lib/mail.server.ts
@@ -12,6 +12,19 @@ export type Mail = {
   text: string;
 };
 
+/**
+ * Body for the mails nobody reads for pleasure — error reports and alerts.
+ * Monospaced and preformatted, because what matters in them is a stack trace
+ * or a column of timestamps, not typography.
+ */
+export function opsMail(body: string): Pick<Mail, "html" | "text"> {
+  const escaped = body.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return {
+    html: `<pre style="font-family:ui-monospace,Menlo,Consolas,monospace; font-size:13px; white-space:pre-wrap;">${escaped}</pre>`,
+    text: body,
+  };
+}
+
 export async function sendMail({ to, subject, html, text }: Mail): Promise<void> {
   const res = await fetch("https://api.resend.com/emails", {
     method: "POST",

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -60,6 +60,8 @@ export default [
       index("routes/manager/index.tsx"),
       route("ligen", "routes/manager/ligen.tsx"),
       route("regelwerke", "routes/manager/regelwerke.tsx"),
+      // Admin-only, see sicherheit.tsx's own gate.
+      route("sicherheit", "routes/manager/sicherheit.tsx"),
       route("spieler", "routes/manager/spieler.tsx"),
       route("start", "routes/manager/start.tsx"),
       route("teams", "routes/manager/teams.tsx"),

--- a/apps/web/app/routes/manager/_sidebar.tsx
+++ b/apps/web/app/routes/manager/_sidebar.tsx
@@ -8,6 +8,7 @@ import {
   LogOutIcon,
   type LucideIcon,
   PilcrowIcon,
+  ShieldAlertIcon,
   ShieldIcon,
   ShirtIcon,
   RocketIcon,
@@ -209,6 +210,28 @@ export function SidebarNav({ slug, isAdmin, collapsed, onNavigate }: SidebarNavP
           />
         </nav>
       </div>
+
+      {isAdmin && (
+        <div className="p-2 pt-0">
+          <p
+            className={cx(
+              "text-muted overflow-hidden px-2 py-1 text-xs font-medium tracking-wider whitespace-nowrap uppercase transition-opacity duration-200",
+              collapsed && "opacity-0",
+            )}
+          >
+            Administration
+          </p>
+          <nav className="mt-1 flex flex-col gap-1">
+            <NavItem
+              to="/manager/sicherheit"
+              icon={ShieldAlertIcon}
+              label="Sicherheit"
+              collapsed={collapsed}
+              onNavigate={onNavigate}
+            />
+          </nav>
+        </div>
+      )}
 
       <div className="border-subtle border-t p-2">
         <Form method="post" action="/logout">

--- a/apps/web/app/routes/manager/sicherheit.tsx
+++ b/apps/web/app/routes/manager/sicherheit.tsx
@@ -1,0 +1,152 @@
+import type { AuthEventType } from "@tipprunde/db/schema";
+import { cx } from "@tipprunde/ui";
+import { data } from "react-router";
+
+import { getAuthEvents } from "#/lib/auth-events.server.ts";
+import { userContext } from "#/lib/context.ts";
+import { isAdmin } from "#/lib/session.server.ts";
+
+import type { Route } from "./+types/sicherheit";
+
+export const handle = { title: "Sicherheit" };
+
+/** The address is in here, so this stays with the admins. */
+export async function loader({ context }: Route.LoaderArgs) {
+  if (!isAdmin(context.get(userContext))) {
+    throw data("Nur für Admins.", { status: 403 });
+  }
+  return getAuthEvents();
+}
+
+const labels: Record<AuthEventType, string> = {
+  code_requested: "Code angefordert",
+  login_succeeded: "Angemeldet",
+  unknown_email: "Unbekannte Adresse",
+  code_invalid: "Falscher Code",
+  code_expired: "Code abgelaufen",
+  code_max_attempts: "Zu viele Fehlversuche",
+  request_failed: "Technischer Fehler",
+  sessions_revoked: "Sitzungen beendet",
+};
+
+/**
+ * Only failures are coloured. Marking successes too — accent orange next to
+ * error orange — made a page of signing in look like a page of alarms, which
+ * is the opposite of what a glance at this should tell you. Everything normal
+ * stays in the body colour, so what is left in red is what to look at.
+ */
+const failureTypes: AuthEventType[] = [
+  "unknown_email",
+  "code_invalid",
+  "code_max_attempts",
+  "request_failed",
+];
+
+function formatMoment(value: string) {
+  const d = new Date(value);
+  return {
+    date: d.toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "2-digit" }),
+    time: d.toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" }),
+  };
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="border-subtle bg-surface-raised rounded-md border px-4 py-3">
+      <div className="text-muted text-xs font-medium tracking-wide uppercase">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+export default function Sicherheit({ loaderData }: Route.ComponentProps) {
+  const { events, logins, failures, total, limit, retentionDays } = loaderData;
+
+  return (
+    <div>
+      <title>Sicherheit | Manager</title>
+
+      {/* The window is said once, above the pair, rather than repeated in both
+          labels — "Fehlversuche (24 h)" wraps to two lines at 375px and leaves
+          the two cards reading at different baselines. */}
+      <h2 className="text-muted mb-2 text-xs font-medium tracking-wide uppercase">
+        Letzte 24 Stunden
+      </h2>
+      <div className="mb-6 grid grid-cols-2 gap-2 sm:max-w-md sm:gap-4">
+        <Stat label="Anmeldungen" value={logins} />
+        <Stat label="Fehlversuche" value={failures} />
+      </div>
+
+      <table className="w-full table-fixed border-collapse text-sm">
+        <thead>
+          <tr>
+            <th className="border-subtle text-muted border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
+              Ereignis
+            </th>
+            {/* Both fold into the first column below xs — three columns do not
+                fit 375px without turning every address into an ellipsis. */}
+            <th className="border-subtle text-muted xs:table-cell hidden border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
+              Wer
+            </th>
+            <th className="border-subtle text-muted xs:table-cell hidden w-28 border-b px-3 py-2.5 text-right text-xs font-medium tracking-wide uppercase">
+              Zeitpunkt
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.length === 0 ? (
+            <tr>
+              <td colSpan={3} className="text-subtle py-16 text-center">
+                Noch nichts passiert.
+              </td>
+            </tr>
+          ) : (
+            events.map((event) => {
+              const { date, time } = formatMoment(event.createdAt);
+              const who = event.user?.name ?? event.email ?? "—";
+
+              return (
+                <tr key={event.id} className="border-subtle border-b last:border-0">
+                  <td className="px-3 py-3">
+                    <div
+                      className={cx(
+                        "font-medium",
+                        failureTypes.includes(event.type) && "text-error",
+                      )}
+                    >
+                      {labels[event.type]}
+                    </div>
+                    <div className="text-subtle xs:hidden mt-0.5 truncate text-xs">
+                      {date}, {time} · {who}
+                    </div>
+                    {event.detail && (
+                      <div className="text-subtle mt-0.5 text-xs">{event.detail}</div>
+                    )}
+                  </td>
+                  <td className="xs:table-cell hidden px-3 py-3">
+                    <div className="truncate">{who}</div>
+                    {/* The address as well when it is not what the name column
+                        already shows — an attempt on a wrong address is only
+                        readable if the address is on the line. */}
+                    {event.user && event.email && (
+                      <div className="text-subtle truncate text-xs">{event.email}</div>
+                    )}
+                  </td>
+                  <td className="text-subtle xs:table-cell hidden px-3 py-3 text-right whitespace-nowrap tabular-nums">
+                    <div>{time}</div>
+                    <div className="text-xs">{date}</div>
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+
+      <p className="text-muted mt-6 text-xs">
+        {total > limit ? `Die ${limit} jüngsten von ${total} Ereignissen.` : `${total} Ereignisse.`}{" "}
+        Gespeichert wird {retentionDays} Tage lang, ohne IP-Adressen.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/routes/manager/sicherheit.tsx
+++ b/apps/web/app/routes/manager/sicherheit.tsx
@@ -35,7 +35,16 @@ const labels: Record<AuthEventType, string> = {
  * is the opposite of what a glance at this should tell you. Everything normal
  * stays in the body colour, so what is left in red is what to look at.
  */
-const failureTypes: AuthEventType[] = [
+/**
+ * Deliberately not the same list as `FAILURE_TYPES` in `auth-events.server.ts`,
+ * which is what counts towards the alert. This one is what earns a second look
+ * — and the two differ at both ends. A technical fault is no attempt at
+ * signing in, but it is something to see; an expired code is a real failed
+ * attempt, and the most ordinary thing here: somebody asked for a code and got
+ * to it ten minutes later. Colouring that too would leave half the list red
+ * within a fortnight, and red stops meaning anything once it is everywhere.
+ */
+const notable: AuthEventType[] = [
   "unknown_email",
   "code_invalid",
   "code_max_attempts",
@@ -109,10 +118,7 @@ export default function Sicherheit({ loaderData }: Route.ComponentProps) {
                 <tr key={event.id} className="border-subtle border-b last:border-0">
                   <td className="px-3 py-3">
                     <div
-                      className={cx(
-                        "font-medium",
-                        failureTypes.includes(event.type) && "text-error",
-                      )}
+                      className={cx("font-medium", notable.includes(event.type) && "text-error")}
                     >
                       {labels[event.type]}
                     </div>

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -7,6 +7,8 @@ import { useState } from "react";
 import * as v from "valibot";
 
 import { SpielerDialog } from "#/components/spieler-dialog.tsx";
+import { logAuthEvent } from "#/lib/auth-events.server.ts";
+import { userContext } from "#/lib/context.ts";
 import { db } from "#/lib/db.server.ts";
 import { getSessionFromRequest, revokeUserSessions } from "#/lib/session.server.ts";
 
@@ -44,7 +46,7 @@ export async function loader() {
   return { users: data };
 }
 
-export async function action({ request }: Route.ActionArgs) {
+export async function action({ request, context }: Route.ActionArgs) {
   const formData = await request.formData();
   const intent = v.parse(v.picklist(["create", "update"]), formData.get("intent"));
 
@@ -99,6 +101,15 @@ export async function action({ request }: Route.ActionArgs) {
     if (existing.email !== values.email) {
       const session = await getSessionFromRequest(request);
       await revokeUserSessions(id, session.get("sessionId"));
+      await logAuthEvent({
+        type: "sessions_revoked",
+        userId: id,
+        // The new address, so the log reads as "this account is reachable here
+        // now". The old one is not kept — it is exactly the kind of trace the
+        // change was meant to end.
+        email: values.email,
+        detail: `Adresse geändert durch ${context.get(userContext)?.name ?? "unbekannt"}`,
+      });
     }
 
     return { user };

--- a/apps/web/app/routes/public/login.tsx
+++ b/apps/web/app/routes/public/login.tsx
@@ -3,6 +3,7 @@ import { ArrowLeftIcon } from "lucide-react";
 import { data, Form, redirect, useNavigation } from "react-router";
 import * as v from "valibot";
 
+import { logAuthEvent } from "#/lib/auth-events.server.ts";
 import { userContext } from "#/lib/context.ts";
 import {
   commitSession,
@@ -68,6 +69,7 @@ export async function action({ request, url }: Route.ActionArgs) {
 
     const user = await findUserByEmail(email);
     if (!user) {
+      await logAuthEvent({ type: "unknown_email", email });
       return fail({ error: "Unbekannte E-Mail Adresse. Frag Micha!", email });
     }
 
@@ -79,6 +81,12 @@ export async function action({ request, url }: Route.ActionArgs) {
       code = await createLoginCode(user.id);
     } catch (err) {
       console.error("[auth] createLoginCode failed:", err);
+      await logAuthEvent({
+        type: "request_failed",
+        userId: user.id,
+        email,
+        detail: `Code konnte nicht erzeugt werden: ${err}`,
+      });
       return fail(
         { error: "Anmeldung gerade nicht möglich. Bitte versuche es später erneut.", email },
         { status: 500 },
@@ -89,11 +97,19 @@ export async function action({ request, url }: Route.ActionArgs) {
       await sendLoginCodeEmail(email, code);
     } catch (err) {
       console.error("[auth] sendLoginCodeEmail failed:", err);
+      await logAuthEvent({
+        type: "request_failed",
+        userId: user.id,
+        email,
+        detail: `Code konnte nicht gesendet werden: ${err}`,
+      });
       return fail(
         { error: "Code konnte nicht gesendet werden. Bitte versuche es erneut.", email },
         { status: 502 },
       );
     }
+
+    await logAuthEvent({ type: "code_requested", userId: user.id, email });
 
     session.set("pendingEmail", email);
     return data(null, { headers: { "Set-Cookie": await commitSession(session) } });
@@ -120,6 +136,7 @@ export async function action({ request, url }: Route.ActionArgs) {
     const result = await verifyLoginCode(user.id, parsed.output);
 
     if (result === "valid") {
+      await logAuthEvent({ type: "login_succeeded", userId: user.id, email });
       const sessionId = await createSession(user.id, rememberMe);
       session.unset("pendingEmail");
       session.set("sessionId", sessionId);
@@ -127,6 +144,19 @@ export async function action({ request, url }: Route.ActionArgs) {
         headers: {
           "Set-Cookie": await commitSession(session, { maxAge: sessionCookieMaxAge(rememberMe) }),
         },
+      });
+    }
+
+    if (result === "invalid" || result === "expired" || result === "max_attempts") {
+      await logAuthEvent({
+        type:
+          result === "invalid"
+            ? "code_invalid"
+            : result === "expired"
+              ? "code_expired"
+              : "code_max_attempts",
+        userId: user.id,
+        email,
       });
     }
 

--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -7,6 +7,8 @@ import compressionMiddleware from "compression";
 import { createRequestHandler, RouterContextProvider } from "react-router";
 import sirv from "sirv";
 
+import { reportServerError } from "#/lib/error-report.server.ts";
+
 type NodeMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
 
 // Railway target — replaces the Cloudflare Workers `workers/app.ts` entry.
@@ -24,6 +26,32 @@ const CLIENT_ASSETS_PATH = path.join(dir, "../dist/client");
 
 const build = await import(BUILD_PATH);
 
+// React Router reads its error hook off the build object — `build.entry.module
+// .handleError`, with a console.error fallback when it is absent — so putting
+// one there covers loaders, actions, resource routes and document rendering
+// alike. The documented route is to reveal `entry.server.tsx` and export it
+// from there, but that means owning 86 lines of streaming, bot detection and
+// timeout handling for the sake of this one hook. The build object is already
+// in our hands, one line above.
+//
+// The trade: this file is production-only (`react-router dev` runs its own
+// Vite server), which suits an alert mail — nobody wants one for every typo in
+// a loader — but does mean the path is exercised by `pnpm build && pnpm start`,
+// not by `pnpm dev`. And `context` cannot be read here: the app's contexts live
+// inside the bundle, so a copy created out here would never match.
+const buildWithErrorReporting = {
+  ...build,
+  entry: {
+    ...build.entry,
+    module: {
+      ...build.entry.module,
+      handleError: (error: unknown, { request }: { request: Request }) => {
+        reportServerError(error, request);
+      },
+    },
+  },
+};
+
 // Everything under dist/client is Vite-content-hashed (no public/ dir in this
 // app), so a one-year immutable cache is always safe.
 const serveAssets = sirv(CLIENT_ASSETS_PATH, {
@@ -40,7 +68,7 @@ const serveAssets = sirv(CLIENT_ASSETS_PATH, {
 // mismatch as a CSRF attempt and answers every action with 400. Railway
 // overwrites the `X-Forwarded-*` headers, so trusting them is sound; locally
 // nothing sends them and the behaviour is unchanged.
-const requestHandler = createRequestHandler(build, process.env.NODE_ENV);
+const requestHandler = createRequestHandler(buildWithErrorReporting, process.env.NODE_ENV);
 
 const handleRequest = createRequestListener(
   (request) => requestHandler(request, new RouterContextProvider()),

--- a/docs/decisions/01-chat.md
+++ b/docs/decisions/01-chat.md
@@ -120,6 +120,46 @@ plain long-lived WebSocket without Durable Objects. That shapes the phases:
   app). Rejected as the default because it is CF-proprietary and prod is heading
   to Railway — only revisit if that changes.
 
+### Consequence (noted 2026-09-08): the dev server has to move too
+
+WebSockets need the raw `http.Server` to handle `upgrade`. In production
+`server/app.ts` already owns it. **In development nothing does** — `pnpm dev`
+runs `react-router dev`, which brings its own Vite server, and `server/app.ts`
+is never loaded. A chat cannot be developed locally with a socket that only
+exists in production, so the custom server has to serve dev as well before this
+work can start.
+
+That is the documented path
+([Running a Custom Server in Development](https://reactrouter.com/api/other-api/adapter#migrating-from-the-react-router-app-server)),
+and it is a restructure, not a flag:
+
+- `server/app.ts` stops importing the build by path (`../dist/server/index.js`,
+  which does not exist in dev) and imports `virtual:react-router/server-build`
+  instead. That makes it part of the Vite SSR build — an input in
+  `vite.config.ts` — rather than a file Node reads directly with type stripping.
+- A thin outer `server.js`, plain JS and outside the build, boots Vite in
+  middleware mode for dev and the built server for production. `--conditions
+development` goes in the dev script.
+- In dev the build must be loaded **per request**, or HMR never takes effect.
+  `createRequestHandler` accepts a function for exactly this and re-derives on
+  each call, so the `handleError` injection (see
+  [07-observability.md](./07-observability.md)) moves inside that function
+  unchanged.
+
+**No Express.** The doc's example uses it, but Vite's middleware is
+Connect-style `(req, res, next)` — the same shape as the `compression` and
+`sirv` handlers `server/app.ts` already chains by hand.
+
+Two things this fixes in passing, both from the observability work:
+
+- `handleError` and `trustProxy` would finally run in development. (Not that
+  `trustProxy` becomes testable — nothing sends `X-Forwarded-*` locally either
+  way.)
+- The report should regain the **user**. It cannot carry one today because
+  `app/lib/context.ts` exists twice — once inside the SSR bundle, once in the
+  raw-Node `server/app.ts` — so `context.get(userContext)` never matches. One
+  Rollup graph means one instance. Expected, not yet measured.
+
 ## Message list UI
 
 TanStack Virtual shipped first-class chat support

--- a/docs/decisions/07-observability.md
+++ b/docs/decisions/07-observability.md
@@ -56,7 +56,10 @@ Two consequences, both accepted:
   not by `pnpm dev`.
 - **No `context`.** The app's contexts live inside the bundle; a copy created
   out in `server/app.ts` would be a different object and never match. So the
-  report carries the request, not the user. The auth log covers the rest.
+  report carries the request, not the user. The auth log covers the rest. This
+  one is expected to lift on its own: when the chat forces the dev server onto
+  `server/app.ts`, that file joins the Vite SSR build and there is only one
+  `context.ts` again — see [01-chat.md](./01-chat.md).
 
 `error-report.server.ts` is therefore loaded by Node directly, with type
 stripping: no JSX, no `import.meta.env`, and relative imports need their file

--- a/docs/decisions/07-observability.md
+++ b/docs/decisions/07-observability.md
@@ -1,0 +1,106 @@
+# Observability — auth events, error mails, alerts
+
+**Status: built (2026-09-04) on `feat/observability`.** Four pieces, in the
+order they had to happen: the `auth_events` table and the logging that fills
+it, an error mail on unhandled server errors, an alert mail when failed
+sign-ins pile up, and `/manager/sicherheit` to look at the result. Rate
+limiting is deliberately **not** built — see the last section.
+
+The gap this closes: nothing told anyone that something had gone wrong. The
+error page says "Bitte versuche es später noch einmal" and offers no way to
+report anything, so a server error only became known if a user happened to
+mention it. Failed sign-ins left no trace at all.
+
+## No Sentry
+
+Considered and dropped. It is another account, another SDK in the bundle, and
+another place the data lives — for a site with around twenty users whose whole
+error surface is one Node process. What was actually wanted is "tell me when
+something breaks", and a mail does that. Resend is already wired up for the
+login code, so the alert path is `sendMail()` and nothing new.
+
+## No IP addresses
+
+The table records the attempted address and, where one matched, the user — but
+never the caller's IP. Behind Railway's proxy an address says little without a
+lookup service, and it is the one field here that would turn a log into
+personal data worth protecting. Retention is 90 days.
+
+The prune runs from the write path rather than a schedule: the table only grows
+when somebody signs in, so the moment a row is added is exactly when a prune is
+worth considering. An in-memory timestamp keeps that to one `DELETE` a day.
+
+Timestamps are written by the app as ISO strings, not left to the column's
+`CURRENT_TIMESTAMP` default. SQLite writes `2026-09-04 12:52:06`, which does
+not compare correctly against an ISO string — and every read of this table is a
+comparison: the prune cutoff, the alert window, the newest-first order.
+
+## `handleError` is injected, not revealed
+
+React Router resolves its error hook as `build.entry.module.handleError`, with
+a `console.error` fallback when it is absent. The documented way to supply one
+is to reveal `entry.server.tsx` and export it from there.
+
+We inject it into the build object in `server/app.ts` instead. Same coverage —
+loaders, actions, resource routes and document rendering all go through that
+one handler — for six lines instead of owning 86 lines of streaming, bot
+detection and timeout handling that we would then have to keep in step with
+every React Router release. The build object is already in hand two lines up,
+in a file that is hand-rolled on purpose anyway (see `02-hosting-railway.md`).
+
+Two consequences, both accepted:
+
+- **Production only.** `react-router dev` runs its own Vite server and never
+  loads `server/app.ts`. That suits an alert mail — nobody wants one for every
+  typo in a loader — but the path is exercised by `pnpm build && pnpm start`,
+  not by `pnpm dev`.
+- **No `context`.** The app's contexts live inside the bundle; a copy created
+  out in `server/app.ts` would be a different object and never match. So the
+  report carries the request, not the user. The auth log covers the rest.
+
+`error-report.server.ts` is therefore loaded by Node directly, with type
+stripping: no JSX, no `import.meta.env`, and relative imports need their file
+extension, which the rest of `lib/` gets away without only because Vite
+resolves it.
+
+## What is not a fault
+
+Aborted requests send nothing — a visitor navigating away mid-request is not an
+error. Neither are route error responses below 500: a 404 for a championship
+that does not exist is the app answering correctly.
+
+Repeats are grouped by message plus innermost stack frame. One mail per
+distinct error per hour, ten an hour at most, so a fault in a loop cannot fill
+a mailbox with the same line.
+
+## The alert threshold
+
+**More than five failed attempts within ten minutes.** The number comes from
+the shape of this site rather than a standard: a round has around twenty
+players, and a legitimate person mistypes twice and then asks Micha.
+
+Counted across the whole site, not per address. Without IP addresses the
+address is the only handle there is, and anyone working through a list of
+guesses would stay under a per-address threshold forever.
+
+An expired code does not count — that is someone who asked for a code and got
+to it too late. A technical failure does not either; that is a fault, and it
+has its own mail.
+
+One alert an hour. An attack that keeps running is still one attack.
+
+## `ALERT_EMAIL` has no default
+
+Unset, errors and alerts are logged and nothing is sent. A guessed default
+would file reports in a mailbox nobody reads, which is worse than none.
+
+## Rate limiting: deliberately later
+
+It was on the original list, and it is not built. Nothing in the data yet says
+where a limit belongs — the table has existed for a day. A limit set from
+imagination either sits so high it never fires or locks out the one player who
+forgot which address they registered with.
+
+The alert is the measurement. Once it has fired a few times, or has not fired
+for a season, the shape of a real limit will be obvious. That is when to build
+it.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,10 +56,16 @@ distinction, but the split still matters for where a value may be written down:
 | `SESSION_DURATION_DEFAULT`  | `86400`            | Session lifetime, seconds          |
 | `SESSION_DURATION_REMEMBER` | `2592000`          | Lifetime with "angemeldet bleiben" |
 | `FROM_EMAIL`                | `hallo@runde.tips` | Sender of the login code mail      |
+| `ALERT_EMAIL`               | —                  | Where server errors are mailed     |
 
 The login flow needs all of them, not just the database pair: without
 `RESEND_API_KEY` or `APP_SECRET` nobody can get a code, and the failure looks
 like a mail problem rather than a missing variable.
+
+`ALERT_EMAIL` has no default on purpose — a wrong guess would send reports into
+a mailbox nobody reads, which is worse than none. Unset, errors are logged and
+no mail goes out. It is only read by the custom server, so it does nothing in
+local development.
 
 ## First-deploy bootstrap
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/packages/db/migrations/20260904125206_auth_events/migration.sql
+++ b/packages/db/migrations/20260904125206_auth_events/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `auth_events` (
+	`id` integer PRIMARY KEY AUTOINCREMENT,
+	`type` text NOT NULL,
+	`user_id` integer,
+	`email` text,
+	`detail` text,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT `fk_auth_events_user_id_users_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE SET NULL
+);
+--> statement-breakpoint
+CREATE INDEX `auth_events_created_at_idx` ON `auth_events` (`created_at`);

--- a/packages/db/migrations/20260904125206_auth_events/snapshot.json
+++ b/packages/db/migrations/20260904125206_auth_events/snapshot.json
@@ -1,0 +1,1288 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "ed1b6d2e-86f0-4f66-829c-f93c5ceb87de",
+  "prevIds": ["e1d503b4-be86-439c-817a-7e50a520a5d3"],
+  "ddl": [
+    {
+      "name": "auth_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "championships",
+      "entityType": "tables"
+    },
+    {
+      "name": "extra_answers",
+      "entityType": "tables"
+    },
+    {
+      "name": "extra_questions",
+      "entityType": "tables"
+    },
+    {
+      "name": "leagues",
+      "entityType": "tables"
+    },
+    {
+      "name": "login_codes",
+      "entityType": "tables"
+    },
+    {
+      "name": "matches",
+      "entityType": "tables"
+    },
+    {
+      "name": "players",
+      "entityType": "tables"
+    },
+    {
+      "name": "round_points",
+      "entityType": "tables"
+    },
+    {
+      "name": "rounds",
+      "entityType": "tables"
+    },
+    {
+      "name": "rulesets",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "tips",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "auth_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "auth_events"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "auth_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "auth_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "detail",
+      "entityType": "columns",
+      "table": "auth_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "auth_events"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "nr",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ruleset_id",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "published",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "completed",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "extra_question_points_published",
+      "entityType": "columns",
+      "table": "championships"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra_question_id",
+      "entityType": "columns",
+      "table": "extra_answers"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "extra_answers"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "answer",
+      "entityType": "columns",
+      "table": "extra_answers"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "points",
+      "entityType": "columns",
+      "table": "extra_answers"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "extra_questions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "championship_id",
+      "entityType": "columns",
+      "table": "extra_questions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "question",
+      "entityType": "columns",
+      "table": "extra_questions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "extra_questions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "answer",
+      "entityType": "columns",
+      "table": "extra_questions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "leagues"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "leagues"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "short_name",
+      "entityType": "columns",
+      "table": "leagues"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "login_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "login_codes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code_hash",
+      "entityType": "columns",
+      "table": "login_codes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "login_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "table": "login_codes"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "round_id",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "nr",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "date",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "league_id",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "hometeam_id",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "awayteam_id",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lowest_sum_bonus",
+      "entityType": "columns",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "championship_id",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rank",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tip_points",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra_question_points",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "round_points",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "total",
+      "entityType": "columns",
+      "table": "players"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "round_id",
+      "entityType": "columns",
+      "table": "round_points"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "round_points"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "points",
+      "entityType": "columns",
+      "table": "round_points"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "championship_id",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "nr",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "published",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "tips_published",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_double_round",
+      "entityType": "columns",
+      "table": "rounds"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tip_rule_id",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joker_rule_id",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "match_rule_id",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "round_rule_id",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra_question_rule_id",
+      "entityType": "columns",
+      "table": "rulesets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "remember_me",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "short_name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "match_id",
+      "entityType": "columns",
+      "table": "tips"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "tips"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tip",
+      "entityType": "columns",
+      "table": "tips"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "points",
+      "entityType": "columns",
+      "table": "tips"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joker",
+      "entityType": "columns",
+      "table": "tips"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra_joker",
+      "entityType": "columns",
+      "table": "tips"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'user'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_auth_events_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "auth_events"
+    },
+    {
+      "columns": ["ruleset_id"],
+      "tableTo": "rulesets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_championships_ruleset_id_rulesets_id_fk",
+      "entityType": "fks",
+      "table": "championships"
+    },
+    {
+      "columns": ["extra_question_id"],
+      "tableTo": "extra_questions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_extra_points_extra_question_id_extra_questions_id_fk",
+      "entityType": "fks",
+      "table": "extra_answers"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_extra_points_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "extra_answers"
+    },
+    {
+      "columns": ["championship_id"],
+      "tableTo": "championships",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_extra_questions_championship_id_championships_id_fk",
+      "entityType": "fks",
+      "table": "extra_questions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_totp_codes_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "login_codes"
+    },
+    {
+      "columns": ["round_id"],
+      "tableTo": "rounds",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_matches_round_id_rounds_id_fk",
+      "entityType": "fks",
+      "table": "matches"
+    },
+    {
+      "columns": ["league_id"],
+      "tableTo": "leagues",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_matches_league_id_leagues_id_fk",
+      "entityType": "fks",
+      "table": "matches"
+    },
+    {
+      "columns": ["hometeam_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_matches_hometeam_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "matches"
+    },
+    {
+      "columns": ["awayteam_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_matches_awayteam_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "matches"
+    },
+    {
+      "columns": ["championship_id"],
+      "tableTo": "championships",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_players_championship_id_championships_id_fk",
+      "entityType": "fks",
+      "table": "players"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_players_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "players"
+    },
+    {
+      "columns": ["round_id"],
+      "tableTo": "rounds",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_round_points_round_id_rounds_id_fk",
+      "entityType": "fks",
+      "table": "round_points"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_round_points_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "round_points"
+    },
+    {
+      "columns": ["championship_id"],
+      "tableTo": "championships",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_rounds_championship_id_championships_id_fk",
+      "entityType": "fks",
+      "table": "rounds"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": ["match_id"],
+      "tableTo": "matches",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_tips_match_id_matches_id_fk",
+      "entityType": "fks",
+      "table": "tips"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "fk_tips_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "tips"
+    },
+    {
+      "columns": ["extra_question_id", "user_id"],
+      "nameExplicit": false,
+      "name": "extra_points_pk",
+      "entityType": "pks",
+      "table": "extra_answers"
+    },
+    {
+      "columns": ["round_id", "user_id"],
+      "nameExplicit": false,
+      "name": "round_points_pk",
+      "entityType": "pks",
+      "table": "round_points"
+    },
+    {
+      "columns": ["match_id", "user_id"],
+      "nameExplicit": false,
+      "name": "tips_pk",
+      "entityType": "pks",
+      "table": "tips"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "auth_events_pk",
+      "table": "auth_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "championships_pk",
+      "table": "championships",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "extra_questions_pk",
+      "table": "extra_questions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "leagues_pk",
+      "table": "leagues",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "totp_codes_pk",
+      "table": "login_codes",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "matches_pk",
+      "table": "matches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "players_pk",
+      "table": "players",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "rounds_pk",
+      "table": "rounds",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "rulesets_pk",
+      "table": "rulesets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "auth_events_created_at_idx",
+      "entityType": "indexes",
+      "table": "auth_events"
+    },
+    {
+      "columns": ["championship_id", "user_id"],
+      "nameExplicit": false,
+      "name": "players_championship_id_user_id_unique",
+      "entityType": "uniques",
+      "table": "players"
+    },
+    {
+      "columns": ["championship_id", "nr"],
+      "nameExplicit": false,
+      "name": "rounds_championship_id_nr_unique",
+      "entityType": "uniques",
+      "table": "rounds"
+    },
+    {
+      "columns": ["slug"],
+      "nameExplicit": false,
+      "name": "championships_slug_unique",
+      "entityType": "uniques",
+      "table": "championships"
+    },
+    {
+      "columns": ["nr"],
+      "nameExplicit": false,
+      "name": "championships_nr_unique",
+      "entityType": "uniques",
+      "table": "championships"
+    },
+    {
+      "columns": ["slug"],
+      "nameExplicit": false,
+      "name": "users_slug_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/relations.ts
+++ b/packages/db/src/relations.ts
@@ -3,6 +3,14 @@ import { defineRelations } from "drizzle-orm";
 import * as schema from "./schema";
 
 export const relations = defineRelations(schema, (r) => ({
+  authEvents: {
+    // Optional on purpose: an unknown address has no user, and a deleted one
+    // leaves its events behind with a null reference.
+    user: r.one.users({
+      from: r.authEvents.userId,
+      to: r.users.id,
+    }),
+  },
   sessions: {
     user: r.one.users({
       from: r.sessions.userId,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,13 @@
 import { sql } from "drizzle-orm";
-import { integer, primaryKey, real, sqliteTable, text, unique } from "drizzle-orm/sqlite-core";
+import {
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  unique,
+} from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -35,6 +43,52 @@ export const loginCodes = sqliteTable("login_codes", {
   expiresAt: text("expires_at").notNull(),
   attempts: integer("attempts").notNull().default(0),
 });
+
+/**
+ * Everything that happens around signing in, successes included.
+ *
+ * Deliberately no IP addresses: the app sits behind a proxy, the addresses
+ * would be of little use without a lookup service, and they are the one field
+ * here that turns a log into personal data worth protecting. What is left is
+ * enough to answer the questions that actually come up — who got in, who kept
+ * failing, and whether an address nobody knows is being tried repeatedly.
+ *
+ * `email` is stored even when no user matches: on a login attempt with an
+ * unknown address, that string is the only thing there is to record.
+ *
+ * Rows expire after 90 days (see `pruneAuthEvents`).
+ */
+export const authEvents = sqliteTable(
+  "auth_events",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    type: text("type", {
+      enum: [
+        "code_requested",
+        "unknown_email",
+        "request_failed",
+        "login_succeeded",
+        "code_invalid",
+        "code_expired",
+        "code_max_attempts",
+        "sessions_revoked",
+      ],
+    }).notNull(),
+    /** Null when no user matched, and again once a user is deleted. */
+    userId: integer("user_id").references(() => users.id, { onDelete: "set null" }),
+    email: text("email"),
+    /** Free text for the cases that need one — a mail error, who revoked what. */
+    detail: text("detail"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  // Every read is "the recent ones", newest first, so the index carries the
+  // order too — the alert query and the overview both ride on it.
+  (table) => [index("auth_events_created_at_idx").on(table.createdAt)],
+);
+
+export type AuthEventType = (typeof authEvents.$inferSelect)["type"];
 
 export const teams = sqliteTable("teams", {
   id: text("id").primaryKey(),


### PR DESCRIPTION
Closes the last item of the five-point backlog: *better monitoring, especially for auth events (wrong email, wrong code, attacks)*.

Nothing told anyone that something had gone wrong. The error page says "Bitte versuche es später noch einmal" and offers no way to report anything, so a server error only became known if a user happened to mention it. Failed sign-ins left no trace at all.

Four pieces, in the order they had to happen — without data, an alert and a view are pointless.

### `auth_events` + logging (`56cdf08`)

One table, one `logAuthEvent()`, wired into every outcome of the login flow and into the session revocation that follows an address change. Successes are recorded too: failures alone answer "is something wrong", but not "was that me", and the second question is the one that gets asked when a session ends unexpectedly.

**No IP addresses.** Behind the proxy they say little without a lookup service, and they are the one field here that would turn a log into personal data worth protecting. The attempted address is enough — and on an attempt with an unknown address it is the only thing there is to record. Rows are dropped after 90 days, pruned from the write path itself.

Logging never throws. A log that can break the login it observes is worse than no log.

### Error mails (`cc37638`)

React Router resolves its error hook as `build.entry.module.handleError`. The documented way to supply one is to reveal `entry.server.tsx`; we inject it into the build object in `server/app.ts` instead. Same coverage — loaders, actions, resource routes, document rendering — for six lines instead of owning 86 lines of streaming, bot detection and timeout handling.

Aborted requests and route error responses below 500 send nothing. Repeats are grouped by message plus innermost stack frame: one mail per distinct error per hour, ten an hour at most.

### Alert mails (`fd0dab6`)

More than five failed attempts within ten minutes, counted across the whole site rather than per address — without IPs the address is the only handle there is, and anyone working through a list of guesses would stay under a per-address threshold forever. An expired code does not count. One alert an hour.

### `/manager/sicherheit` (`85d2904`)

The sign-in log behind its own admin gate, because the addresses are in it. Two numbers for the last 24 hours, then the events. Only failures are coloured — marking successes as well put accent orange next to error orange and made a page of people signing in look like a page of alarms.

### Verified

- Logging end to end: unknown address in the browser → row in the DB.
- Error mail: production build run locally, error thrown in a loader — `handleError` is reached. Five identical errors produced exactly one mail attempt.
- Alert: five failures → nothing, the sixth → alert, the seventh silent (cooldown).
- The page at 375px and desktop, light and dark, no horizontal overflow.

Mail paths were exercised with an invalid Resend key so nothing went out.

### Before merging

- **`ALERT_EMAIL`** must be set per environment. Unset, everything is logged and no mail is sent — deliberately no default, a guessed recipient would file reports in a mailbox nobody reads.
- **Migration `20260904125206_auth_events`** is on the dev DB, which the PR build uses, so this build is complete. **Prod still needs `db:migrate:prod`** — without the table, sign-ins log an error to stderr and `/manager/sicherheit` fails. (Staging is currently unused.)

### Not built, on purpose

**Rate limiting** was on the original list. Nothing in the data says yet where a limit belongs; set from imagination it either never fires or locks out the one player who forgot which address they registered with. The alert is the measurement that has to come first.

**Lazy loading** of the event list. It is capped at 200 rather than paged — the page answers "what happened lately". If the volume ever makes that cap bite, paging is the next step.

Reasoning recorded in `docs/decisions/07-observability.md`; `01-chat.md` gains the note that the chat's WebSockets will force the dev server onto `server/app.ts` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

