### PR TITLE
Let an admin end a player's sessions, and sweep stale ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.8.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.7.0...v1.8.0)
+
+### 🚀 Enhancements
+
+- **web:** Let an admin end a player's sessions, and sweep stale ones ([326269e](https://github.com/haus23/tipprunde/commit/326269e))
+
+### 🩹 Fixes
+
+- **web:** Hide the session button where it can't do anything, say so when it doesn't ([acfcfb0](https://github.com/haus23/tipprunde/commit/acfcfb0))
+
 ## v1.7.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.6.2...v1.7.0)

--- a/apps/web/app/lib/session.server.ts
+++ b/apps/web/app/lib/session.server.ts
@@ -115,15 +115,21 @@ export function sessionCookieMaxAge(rememberMe: boolean): number | undefined {
  * `keepSessionId` spares the caller's own session, so an admin correcting their
  * own address does not log themselves out mid-edit. Editing someone else, that
  * id belongs to a different user and the clause simply never matches.
+ *
+ * Returns how many rows it removed, so a caller acting on demand (the manual
+ * "Sitzungen beenden" button, not the address-change side effect) can tell a
+ * real revocation from a click that had nothing to do.
  */
-export async function revokeUserSessions(userId: number, keepSessionId?: string) {
-  await db
+export async function revokeUserSessions(userId: number, keepSessionId?: string): Promise<number> {
+  const deleted = await db
     .delete(sessions)
     .where(
       keepSessionId
         ? and(eq(sessions.userId, userId), ne(sessions.id, keepSessionId))
         : eq(sessions.userId, userId),
-    );
+    )
+    .returning({ id: sessions.id });
+  return deleted.length;
 }
 
 export async function deleteSession(sessionId: string) {

--- a/apps/web/app/lib/session.server.ts
+++ b/apps/web/app/lib/session.server.ts
@@ -1,5 +1,5 @@
 import { sessions } from "@tipprunde/db/schema";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, lt, ne } from "drizzle-orm";
 import { createCookieSessionStorage } from "react-router";
 
 import type { User } from "./context";
@@ -7,6 +7,10 @@ import { db } from "./db.server";
 
 const SESSION_DURATION_DEFAULT = Number(process.env["SESSION_DURATION_DEFAULT"]);
 const SESSION_DURATION_REMEMBER = Number(process.env["SESSION_DURATION_REMEMBER"]);
+
+const PRUNE_INTERVAL = 24 * 60 * 60 * 1000;
+/** In memory, so it resets on every deploy — one extra prune after a release. */
+let lastPrune = 0;
 
 /**
  * Only ids travel in the cookie; everything else stays in the DB.
@@ -72,7 +76,28 @@ export async function createSession(userId: number, rememberMe: boolean): Promis
   const duration = rememberMe ? SESSION_DURATION_REMEMBER : SESSION_DURATION_DEFAULT;
   const expiresAt = new Date(Date.now() + duration * 1000).toISOString();
   await db.insert(sessions).values({ id, userId, rememberMe, expiresAt });
+
+  // Piggybacks on login rather than every request: the table only grows when
+  // someone signs in, so that is exactly when a sweep of the dead rows is
+  // worth considering. There is no judgment call here — expired means
+  // expired, always safe to delete — so this needs no admin action to trigger
+  // it, unlike revokeUserSessions.
+  await pruneExpiredSessions();
+
   return id;
+}
+
+async function pruneExpiredSessions(): Promise<void> {
+  const now = Date.now();
+  if (now - lastPrune < PRUNE_INTERVAL) return;
+  lastPrune = now;
+
+  try {
+    await db.delete(sessions).where(lt(sessions.expiresAt, new Date(now).toISOString()));
+  } catch (err) {
+    // A failed sweep must not break the login it rode in on.
+    console.error("[session] prune failed:", err);
+  }
 }
 
 /** Cookie lifetime mirrors the DB session's — a session cookie unless remembered. */

--- a/apps/web/app/routes/manager/_sessions-dialog.tsx
+++ b/apps/web/app/routes/manager/_sessions-dialog.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@tipprunde/ui";
+import { Dialog, Heading, Modal, ModalOverlay } from "react-aria-components";
+import { useFetcher } from "react-router";
+
+type SessionsFormProps = {
+  userId: number;
+  name: string;
+  onClose: () => void;
+};
+
+function SessionsForm({ userId, name, onClose }: SessionsFormProps) {
+  const fetcher = useFetcher<{ revoked?: boolean; errors?: { revoke: string[] } }>();
+  const isPending = fetcher.state !== "idle";
+  const isDone = fetcher.state === "idle" && fetcher.data !== undefined;
+  const error = fetcher.data?.errors?.revoke?.[0];
+
+  // No auto-close on success, unlike the other dialogs in this folder: nothing
+  // else on this page visibly changes, so closing silently would leave no
+  // sign that anything happened at all.
+  if (isDone && !error) {
+    return (
+      <div className="flex flex-col gap-5">
+        <p className="text-sm">
+          Alle Sitzungen von <span className="font-medium">{name}</span> wurden beendet.
+        </p>
+        <div className="flex justify-end">
+          <Button onPress={onClose}>Schließen</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm">
+        Alle Sitzungen von <span className="font-medium">{name}</span> werden beendet. {name} muss
+        sich beim nächsten Besuch neu anmelden — die E-Mail-Adresse bleibt unverändert.
+      </p>
+      {error && <p className="text-error text-sm">{error}</p>}
+      <div className="flex justify-end gap-3">
+        <Button intent="secondary" onPress={onClose} isDisabled={isPending}>
+          Abbrechen
+        </Button>
+        <Button
+          isDisabled={isPending}
+          onPress={() =>
+            void fetcher.submit(
+              { intent: "revoke-sessions", userId: String(userId) },
+              { method: "post" },
+            )
+          }
+        >
+          {isPending ? "…" : "Sitzungen beenden"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type SessionsDialogProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  userId: number;
+  name: string;
+};
+
+/**
+ * Confirm-and-revoke, admin only — see spieler.tsx's own gate on the action.
+ * Deliberately does not touch the address: this is "kick this account out
+ * everywhere right now", not the side effect that already follows an address
+ * change.
+ */
+export function SessionsDialog({ isOpen, onOpenChange, userId, name }: SessionsDialogProps) {
+  const onClose = () => onOpenChange(false);
+
+  return (
+    <ModalOverlay
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      isDismissable
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+    >
+      <Modal className="bg-surface-raised border-subtle w-full max-w-sm rounded-md border shadow-xl outline-none">
+        <Dialog className="outline-none">
+          <div className="border-subtle border-b px-6 py-4">
+            <Heading slot="title" className="text-base font-semibold">
+              Sitzungen beenden
+            </Heading>
+          </div>
+          <div className="px-6 py-5">
+            {isOpen && <SessionsForm userId={userId} name={name} onClose={onClose} />}
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}

--- a/apps/web/app/routes/manager/_sessions-dialog.tsx
+++ b/apps/web/app/routes/manager/_sessions-dialog.tsx
@@ -9,7 +9,11 @@ type SessionsFormProps = {
 };
 
 function SessionsForm({ userId, name, onClose }: SessionsFormProps) {
-  const fetcher = useFetcher<{ revoked?: boolean; errors?: { revoke: string[] } }>();
+  const fetcher = useFetcher<{
+    revoked?: boolean;
+    count?: number;
+    errors?: { revoke: string[] };
+  }>();
   const isPending = fetcher.state !== "idle";
   const isDone = fetcher.state === "idle" && fetcher.data !== undefined;
   const error = fetcher.data?.errors?.revoke?.[0];
@@ -18,10 +22,20 @@ function SessionsForm({ userId, name, onClose }: SessionsFormProps) {
   // else on this page visibly changes, so closing silently would leave no
   // sign that anything happened at all.
   if (isDone && !error) {
+    const count = fetcher.data?.count ?? 0;
     return (
       <div className="flex flex-col gap-5">
         <p className="text-sm">
-          Alle Sitzungen von <span className="font-medium">{name}</span> wurden beendet.
+          {count > 0 ? (
+            <>
+              Alle Sitzungen von <span className="font-medium">{name}</span> wurden beendet.
+            </>
+          ) : (
+            <>
+              <span className="font-medium">{name}</span> hatte keine aktive Sitzung — nichts zu
+              tun.
+            </>
+          )}
         </p>
         <div className="flex justify-end">
           <Button onPress={onClose}>Schließen</Button>

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -2,18 +2,20 @@ import { users } from "@tipprunde/db/schema";
 import { Button, SearchField } from "@tipprunde/ui";
 import { eq } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-orm/valibot";
-import { PencilIcon, PlusIcon } from "lucide-react";
+import { LogOutIcon, PencilIcon, PlusIcon } from "lucide-react";
 import { useState } from "react";
+import { data } from "react-router";
 import * as v from "valibot";
 
 import { SpielerDialog } from "#/components/spieler-dialog.tsx";
 import { logAuthEvent } from "#/lib/auth-events.server.ts";
 import { userContext } from "#/lib/context.ts";
 import { db } from "#/lib/db.server.ts";
-import { getSessionFromRequest, revokeUserSessions } from "#/lib/session.server.ts";
+import { getSessionFromRequest, isAdmin, revokeUserSessions } from "#/lib/session.server.ts";
 import { sortGerman } from "#/lib/utils.ts";
 
 import type { Route } from "./+types/spieler";
+import { SessionsDialog } from "./_sessions-dialog.tsx";
 
 type User = typeof users.$inferSelect;
 
@@ -42,14 +44,41 @@ const spielerSchema = createInsertSchema(users, {
   role: v.picklist(["user", "manager", "admin"]),
 });
 
-export async function loader() {
-  const data = await db.query.users.findMany();
-  return { users: sortGerman(data, (u) => u.name) };
+export async function loader({ context }: Route.LoaderArgs) {
+  const rows = await db.query.users.findMany();
+  return {
+    users: sortGerman(rows, (u) => u.name),
+    // Gates the "Sitzungen beenden" button — the action re-checks this itself,
+    // this only decides whether it renders at all.
+    canRevokeSessions: isAdmin(context.get(userContext)),
+  };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
   const formData = await request.formData();
-  const intent = v.parse(v.picklist(["create", "update"]), formData.get("intent"));
+  const intent = v.parse(
+    v.picklist(["create", "update", "revoke-sessions"]),
+    formData.get("intent"),
+  );
+
+  if (intent === "revoke-sessions") {
+    if (!isAdmin(context.get(userContext))) {
+      throw data("Nur für Admins.", { status: 403 });
+    }
+    const id = Number(formData.get("userId"));
+    const target = await db.query.users.findFirst({ where: { id } });
+    if (!target) return { errors: { revoke: ["Spieler nicht gefunden."] } };
+
+    const session = await getSessionFromRequest(request);
+    await revokeUserSessions(id, session.get("sessionId"));
+    await logAuthEvent({
+      type: "sessions_revoked",
+      userId: id,
+      email: target.email,
+      detail: `Manuell beendet durch ${context.get(userContext)?.name ?? "unbekannt"}`,
+    });
+    return { revoked: true };
+  }
 
   const result = v.safeParse(spielerSchema, Object.fromEntries(formData));
 
@@ -120,10 +149,11 @@ export async function action({ request, context }: Route.ActionArgs) {
 }
 
 export default function Spieler({ loaderData }: Route.ComponentProps) {
-  const { users: userList } = loaderData;
+  const { users: userList, canRevokeSessions } = loaderData;
   const [filter, setFilter] = useState("");
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [sessionsUser, setSessionsUser] = useState<User | null>(null);
 
   const filtered = userList.filter(
     (u) => !filter || `${u.name} ${u.slug}`.toLowerCase().includes(filter.toLowerCase()),
@@ -151,7 +181,7 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
             <th className="border-subtle text-muted border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Name
             </th>
-            {/* Both drop out below xs: the fixed widths alone (224 + 112 + 48)
+            {/* Both drop out below xs: the fixed widths alone (224 + 112 + 96)
                 already exceed a 375px screen. The address is not lost — the
                 edit dialog shows it, which is where a change request ends up
                 anyway. */}
@@ -161,7 +191,10 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
             <th className="border-subtle text-muted xs:table-cell hidden w-28 border-b px-3 py-2.5 text-left text-xs font-medium tracking-wide uppercase">
               Rolle
             </th>
-            <th className="border-subtle w-12 border-b" />
+            {/* Wide enough for two icon buttons once the session action joins
+                the pencil — sized for admins, who see both; a plain manager's
+                row just carries the unused space. */}
+            <th className="border-subtle w-24 border-b" />
           </tr>
         </thead>
         <tbody>
@@ -186,14 +219,26 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
                   {roleLabels[user.role]}
                 </td>
                 <td className="px-3 py-3 text-right">
-                  <Button
-                    intent="ghost"
-                    size="icon"
-                    onPress={() => setEditingUser(user)}
-                    aria-label={`${user.name} bearbeiten`}
-                  >
-                    <PencilIcon className="size-4" />
-                  </Button>
+                  <div className="flex justify-end gap-1">
+                    {canRevokeSessions && (
+                      <Button
+                        intent="ghost"
+                        size="icon"
+                        onPress={() => setSessionsUser(user)}
+                        aria-label={`Sitzungen von ${user.name} beenden`}
+                      >
+                        <LogOutIcon className="size-4" />
+                      </Button>
+                    )}
+                    <Button
+                      intent="ghost"
+                      size="icon"
+                      onPress={() => setEditingUser(user)}
+                      aria-label={`${user.name} bearbeiten`}
+                    >
+                      <PencilIcon className="size-4" />
+                    </Button>
+                  </div>
                 </td>
               </tr>
             ))
@@ -212,6 +257,15 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
         onOpenChange={(open) => !open && setEditingUser(null)}
         defaultValues={editingUser ?? undefined}
       />
+
+      {sessionsUser && (
+        <SessionsDialog
+          isOpen={!!sessionsUser}
+          onOpenChange={(open) => !open && setSessionsUser(null)}
+          userId={sessionsUser.id}
+          name={sessionsUser.name}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -70,14 +70,20 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (!target) return { errors: { revoke: ["Spieler nicht gefunden."] } };
 
     const session = await getSessionFromRequest(request);
-    await revokeUserSessions(id, session.get("sessionId"));
-    await logAuthEvent({
-      type: "sessions_revoked",
-      userId: id,
-      email: target.email,
-      detail: `Manuell beendet durch ${context.get(userContext)?.name ?? "unbekannt"}`,
-    });
-    return { revoked: true };
+    const count = await revokeUserSessions(id, session.get("sessionId"));
+
+    // Nothing to log when nothing happened — an admin action that changed
+    // zero rows is not worth the same audit weight as one that actually
+    // ended a session.
+    if (count > 0) {
+      await logAuthEvent({
+        type: "sessions_revoked",
+        userId: id,
+        email: target.email,
+        detail: `Manuell beendet durch ${context.get(userContext)?.name ?? "unbekannt"}`,
+      });
+    }
+    return { revoked: true, count };
   }
 
   const result = v.safeParse(spielerSchema, Object.fromEntries(formData));
@@ -220,7 +226,10 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
                 </td>
                 <td className="px-3 py-3 text-right">
                   <div className="flex justify-end gap-1">
-                    {canRevokeSessions && (
+                    {/* Without an address there is no login path at all, and
+                        clearing one already revokes whatever existed — so no
+                        email means provably no session to end. */}
+                    {canRevokeSessions && user.email && (
                       <Button
                         intent="ghost"
                         size="icon"

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -40,27 +40,45 @@ enough on its own. The original page had exactly this bug on the JSON field
 issues fell back to the bullet list below). Both fields now set
 `isInvalid={!!errors?.field?.length}` explicitly.
 
-### "Alle Sitzungen beenden" for one player
+### "Alle Sitzungen beenden" for one player — done
 
 Deferred since v1.5.0, when changing an address started revoking sessions
-automatically. `revokeUserSessions()` in `lib/session.server.ts` already does
-the work and takes an optional session to spare.
+automatically. `revokeUserSessions()` already did the work and already took
+an optional session to spare — only the trigger and the path to it were
+missing.
 
-**Settled:** it ends _one player's_ sessions, and it belongs on the Spieler
-page — same place as the address that would prompt it.
+**Admin-only, and address untouched.** A second icon button beside the pencil
+on `/manager/spieler`, gated in the loader (`canRevokeSessions`) and re-gated
+in the action itself, the same way `sicherheit.tsx`/`import.tsx` gate their
+own routes — a plain manager can still edit players, but not end their
+sessions. Behind a confirmation dialog (`_sessions-dialog.tsx`, the
+`_runde-dialog.tsx` shape reused), because it cannot be undone and logs a real
+person out. Logged the same way an address change already is —
+`sessions_revoked` in `auth_events`, distinguished by its `detail` text
+("Manuell beendet durch …" vs "Adresse geändert durch …").
 
-**The real problem is the path to it.** Today every player action hides behind
-a two-step route: find the row, open the edit dialog, act. For "throw this
-account out now" that is both slow and unintuitive — it is not an edit, and it
-does not belong on a form whose Save button does something else. Wanted
-instead: reachable from the row, with its own confirmation dialog, because it
-cannot be undone and logs a real person out.
+Stayed off `/manager/sicherheit` as planned — that page still only reads.
 
-**Not on `/manager/sicherheit`.** That page is a log and should stay one —
-mixing "what happened" with "do something about it" makes a read-only page
-dangerous to click around in. What would earn its place there is the opposite
-direction: an event row linking _to_ the player, so the log leads to the action
-instead of containing it.
+### Stale sessions, across all users — done
+
+Came up while building the above, not originally on this list.
+
+Not "when it could happen" but "when doesn't it": every session has a fixed
+`expiresAt` set once at login and nothing ever renews it, so every session a
+user does not explicitly log out of eventually sits in the table dead. Logout
+is the only path that removes a row before its natural expiry, and most
+people just close the tab.
+
+No button. Unlike ending one player's sessions, there is no judgment call
+here — expired means expired, always safe to delete. A button would imply a
+reason not to.
+
+Piggybacks on `createSession()` — the exact `pruneAuthEvents()` shape from
+`auth-events.server.ts`, an in-memory `lastPrune` throttled to once a day, so
+a login is "the table just grew, worth considering a sweep" the same way an
+auth event write already is. No cron: this app has none on purpose (Railway,
+single process). At ~23 users the table never gets large enough to matter
+either way — this is tidiness, not a performance fix.
 
 ## B · Sorting German names
 
@@ -200,7 +218,6 @@ Deferred earlier with reasons that still hold.
 
 1. **C (login)** — done.
 2. **B (sorting)** — done.
-3. **A (navigation)** — import move done; the session action still needs a
-   route out of the edit dialog.
+3. **A (navigation)** — done.
 4. **D (Archiv)** — the discussion, then the heading.
 5. **E** — as time and mood allow; the chat last, and knowingly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Part of `docs/backlog.md` item A. Two session-management gaps, both raised in the same conversation.

## End one player's sessions, on demand

`revokeUserSessions()` already existed — it's what an address change already triggers — but the only way to reach it was to change the address, which the player might not want touched at all. A second icon button next to the edit pencil on `/manager/spieler` calls it directly, address untouched.

Admin-only, re-checked in the action itself rather than trusting the button being hidden — the same shape `sicherheit.tsx` and `import.tsx` already use to gate a single route inside the generally manager-accessible layout. Behind a confirmation dialog (`_sessions-dialog.tsx`, reusing `_runde-dialog.tsx`'s shape) because it cannot be undone and logs a real person out; it does not auto-close on success, since nothing else on the page visibly changes to prove it happened. Logged as `sessions_revoked` in `auth_events`, the same event type the address-change path already writes, distinguished by its `detail` text.

## Sweep sessions nobody logged out of

Every session gets a fixed `expiresAt` at login and nothing ever renews it, so every session a user doesn't explicitly log out of eventually goes stale — and logout only fires if someone clicks it rather than just closing the tab, the common case. Nothing ever deleted those rows.

No button for this one: unlike ending a specific player's sessions, there's no judgment call in "expired means expired" — a button would imply a reason not to. Piggybacks on `createSession()` instead, reusing `pruneAuthEvents()`'s exact shape from the observability branch: an in-memory timestamp throttles it to once a day, so a login is "the table just grew, worth considering a sweep" the same way writing an auth event already is.

## Verified

- The button is admin-gated (hidden for a plain manager, checked again server-side).
- Confirmation dialog reads correctly, doesn't auto-close.
- Ending a seeded test player's sessions (including an already-expired one) removed all of them and logged the event with the right detail text.
- Edge case: a player with no email and no session history — a harmless no-op, not a bug. (What an odd-looking log entry during testing turned out to be.)
- The prune query, checked directly against the dev database: matches only an expired seeded row, none of six valid ones.

**Not re-verified end-to-end:** the throttled prune code path itself, since exercising it would have meant restarting the long-running local dev server rather than one I control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)