### PR TITLE
Add a joker rule for a pooled group-stage budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.9.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.8.0...v1.9.0)
+
+### 🚀 Enhancements
+
+- **web:** Add a joker rule for a pooled group-stage budget ([a9fe451](https://github.com/haus23/tipprunde/commit/a9fe451))
+
+### 📖 Documentation
+
+- Say Railway, not Cloudflare Workers, in the README ([12d4eda](https://github.com/haus23/tipprunde/commit/12d4eda))
+- Document the import route's JSON schema and its scaling options ([0744f24](https://github.com/haus23/tipprunde/commit/0744f24))
+
+### 🏡 Chore
+
+- **web:** Fix the four pnpm check warnings ([d68fcf3](https://github.com/haus23/tipprunde/commit/d68fcf3))
+- Bump lucide-react, react-aria-components, @types/node, @types/react-dom ([9058c15](https://github.com/haus23/tipprunde/commit/9058c15))
+- Replace vite-plus with oxfmt + oxlint directly ([59f1d6d](https://github.com/haus23/tipprunde/commit/59f1d6d))
+
 ## v1.8.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.7.0...v1.8.0)

--- a/apps/web/app/routes/manager/championship/tipps.tsx
+++ b/apps/web/app/routes/manager/championship/tipps.tsx
@@ -327,6 +327,8 @@ type TipGridProps = {
   jokerRuleId: string | null;
   jokerCount: number;
   roundJokerCount: number;
+  currentRoundNr: number;
+  vorrundeJokerCount: number;
   hasExtraJoker: boolean;
   extraJokerCount: number;
 };
@@ -337,6 +339,8 @@ function TipGrid({
   jokerRuleId,
   jokerCount,
   roundJokerCount,
+  currentRoundNr,
+  vorrundeJokerCount,
   hasExtraJoker,
   extraJokerCount,
 }: TipGridProps) {
@@ -372,6 +376,10 @@ function TipGrid({
     )
       return roundJokerCount === 0 || currentlyChecked;
     if (jokerRuleId === "zwei-pro-turnier") return jokerCount < 2 || currentlyChecked;
+    if (jokerRuleId === "drei-joker-vorrunde-dann-einmal-pro-runde") {
+      if (currentRoundNr <= 3) return vorrundeJokerCount < 3 || currentlyChecked;
+      return roundJokerCount === 0 || currentlyChecked;
+    }
     return false;
   }
 
@@ -664,6 +672,12 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
   const jokerCount = allMatches.filter((m) => m.tips[0]?.joker).length;
   const roundJokerCount = currentMatches.filter((m) => m.tips[0]?.joker).length;
   const extraJokerCount = allMatches.filter((m) => m.tips[0]?.extraJoker).length;
+  // "drei-joker-vorrunde-dann-einmal-pro-runde" pools its budget across the
+  // first three rounds (the WM group stage) rather than per round.
+  const vorrundeRoundIds = new Set(rounds.filter((r) => r.nr <= 3).map((r) => r.id));
+  const vorrundeJokerCount = allMatches.filter(
+    (m) => vorrundeRoundIds.has(m.roundId) && m.tips[0]?.joker,
+  ).length;
 
   return (
     <div className="space-y-6">
@@ -728,6 +742,8 @@ export default function Tipps({ loaderData }: Route.ComponentProps) {
               jokerRuleId={jokerRuleId}
               jokerCount={jokerCount}
               roundJokerCount={roundJokerCount}
+              currentRoundNr={currentRound?.nr ?? 0}
+              vorrundeJokerCount={vorrundeJokerCount}
               hasExtraJoker={hasExtraJoker}
               extraJokerCount={extraJokerCount}
             />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/packages/domain/src/rules.ts
+++ b/packages/domain/src/rules.ts
@@ -37,6 +37,12 @@ export const JOKER_RULES = [
     description:
       "Auf einen Tipp kann ein Joker gesetzt werden. Die Punkte dieses Tipps werden verdoppelt. Pro Runde kann maximal ein Joker gesetzt werden. Zusätzlich können im gesamten Turnier bis zu zwei zusätzliche Joker für je 1 Euro gekauft werden. Auf einen Tipp können nicht beide Joker gesetzt werden.",
   },
+  {
+    value: "drei-joker-vorrunde-dann-einmal-pro-runde" as const,
+    label: "Drei Joker in der Vorrunde, danach einmal pro Runde",
+    description:
+      "Auf einen Tipp kann ein Joker gesetzt werden. Die Punkte dieses Tipps werden verdoppelt. In den ersten drei Runden stehen insgesamt maximal drei Joker zur Verfügung. Ab der vierten Runde kann pro Runde maximal ein Joker gesetzt werden.",
+  },
 ];
 
 export const MATCH_RULES = [


### PR DESCRIPTION
## Warum

WM 2006 (der nächste Legacy-Import) hatte eine Joker-Regel, die keine der drei bestehenden abbildet: drei Joker gepoolt über die ersten drei Runden (die WM-Vorrunde, aufgeteilt in 16/16/16 statt einer 32er-Runde), danach ab Runde 4 (Endrunde/KO-Phase) wieder ein Joker pro Runde.

## Was

- Neuer `JOKER_RULES`-Eintrag `drei-joker-vorrunde-dann-einmal-pro-runde` in [`packages/domain/src/rules.ts`](../blob/main/packages/domain/src/rules.ts)
- `isJokerAllowed()` in [`tipps.tsx`](../blob/main/apps/web/app/routes/manager/championship/tipps.tsx) erkennt die Regel: Runde 1–3 zählt gegen ein Turnier-weites Pool-Budget von 3, ab Runde 4 gilt wieder das normale Runden-Budget.

Folgt dem bestehenden Muster einer rundenzahl-verankerten Sonderregel (`niedrigste-spielsumme-doppelte-punkte-ab-runde-3`) statt ein neues Schema-Konzept für "Phase" einzuführen.

## Test

Bisher nur im Formular verifiziert (neue Option erscheint korrekt mit Label/Beschreibung). Der eigentliche Live-Test der Budget-Logik passiert im Anschluss auf dem PR-Build mit dem echten WM-2006-Import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)