### PR TITLE
Respect prefers-reduced-motion; grow icon-button hit areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.10.0
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.9.0...v1.10.0)
+
+### 🚀 Enhancements
+
+- **theme:** Respect prefers-reduced-motion globally ([a9ed07b](https://github.com/haus23/tipprunde/commit/a9ed07b))
+- **web:** Grow icon-button hit areas toward 44px ([6743530](https://github.com/haus23/tipprunde/commit/6743530))
+
 ## v1.9.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.8.0...v1.9.0)

--- a/apps/web/app/components/color-scheme-toggle.tsx
+++ b/apps/web/app/components/color-scheme-toggle.tsx
@@ -42,7 +42,14 @@ export function ColorSchemeToggle() {
   }
 
   return (
-    <Button intent="ghost" size="icon" onPress={toggle}>
+    <Button
+      intent="ghost"
+      size="icon"
+      onPress={toggle}
+      // Only 4px from the user-area button on its right — cap that one side
+      // so the expanded hit areas meet instead of overlapping (see button.tsx).
+      className="-mr-0.5 pr-2"
+    >
       {/*
         Icon and label are CSS-driven on purpose: while "system" is stored the
         server cannot know the resolved scheme, so picking either in JS would

--- a/apps/web/app/routes/manager/spieler.tsx
+++ b/apps/web/app/routes/manager/spieler.tsx
@@ -235,6 +235,9 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
                         size="icon"
                         onPress={() => setSessionsUser(user)}
                         aria-label={`Sitzungen von ${user.name} beenden`}
+                        // 4px from the edit button — cap the facing side so
+                        // the expanded hit areas meet, not overlap.
+                        className="-mr-0.5 pr-2"
                       >
                         <LogOutIcon className="size-4" />
                       </Button>
@@ -244,6 +247,7 @@ export default function Spieler({ loaderData }: Route.ComponentProps) {
                       size="icon"
                       onPress={() => setEditingUser(user)}
                       aria-label={`${user.name} bearbeiten`}
+                      className={canRevokeSessions && user.email ? "-ml-0.5 pl-2" : undefined}
                     >
                       <PencilIcon className="size-4" />
                     </Button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",

--- a/packages/theme/src/theme.css
+++ b/packages/theme/src/theme.css
@@ -163,3 +163,19 @@
     block-size: auto;
   }
 }
+
+/* Global motion-reduction switch. Collapses every transition and animation
+   in the project to effectively nothing — the accordion above, the switch
+   knob, the press-scale on buttons, all of it — without hunting down each
+   site individually. `!important` is the point: this has to win over every
+   component-level `transition-*` utility without them opting in. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -20,7 +20,14 @@ const buttonClasses = cva({
     size: {
       md: "px-4 py-2 text-sm",
       sm: "px-3 py-1.5 text-sm",
-      icon: "p-1.5",
+      // Visually still a 28px square (matches WCAG 2.5.8's 24px minimum with
+      // room to spare) — the padding/negative-margin pair only grows the
+      // *hit* area, toward Apple/Material's 44px target, without pushing
+      // neighbors around: -m-2 (-8px) cancels p-3.5 (+14px) back down to the
+      // original p-1.5 (6px) footprint. Where a neighbor sits closer than
+      // 16px away, cap the facing side locally (see color-scheme-toggle.tsx,
+      // spieler.tsx) rather than shrinking this for everyone.
+      icon: "-m-2 p-3.5",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
Zwei vertagte Punkte aus dem Responsive-Branch (`docs/backlog.md` E), jetzt umgesetzt.

## `prefers-reduced-motion`

Ein globaler Block in [`theme.css`](../blob/main/packages/theme/src/theme.css) kollabiert jede Transition/Animation im Projekt, wenn die OS-Einstellung aktiv ist — Accordion, Switch-Knopf, Press-Scale, alles auf einmal statt Stelle für Stelle.

## 28px-Icon-Buttons → 44px-Hit-Area

[`Button`](../blob/main/packages/ui/src/components/button.tsx)s `icon`-Variante bleibt visuell eine 28px-Box (über WCAG 2.5.8's 24px-Minimum), wächst aber per Padding/Negativ-Margin-Trick (wie beim `jokerHitArea` im Tipp-Grid) auf ~44px Hit-Fläche, ohne Nachbarn zu verschieben.

Zwei Stellen sitzen näher als 16px an einem weiteren Icon-Button und würden sonst überlappen — lokal auf der betroffenen Seite gekappt, live vermessen:
- Header: Farbschema-Umschalter ↔ Nutzer-Button (4px)
- `/manager/spieler`: Sitzungen-beenden ↔ Bearbeiten (4px)

Alle anderen ~17 Stellen bekommen die volle Erweiterung ohne Anpassung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)