### PR TITLE
Bump cva to 1.0.0-beta.9, migrate off deprecated config

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.4",
-    "cva": "1.0.0-beta.8",
+    "clsx": "catalog:tailwind",
+    "cva": "1.0.0-beta.9",
     "lucide-react": "catalog:icons",
     "tailwind-merge": "catalog:tailwind"
   },

--- a/packages/ui/src/lib/cva.ts
+++ b/packages/ui/src/lib/cva.ts
@@ -1,8 +1,11 @@
-import { defineConfig } from "cva";
+import { clsx } from "clsx";
+import { defineConfig } from "cva/config";
 import { twMerge } from "tailwind-merge";
 
+// `hooks.onComplete` is deprecated as of cva@1.0.0-beta.9 in favor of `cx`,
+// which now owns the whole join-then-merge step (it receives the raw inputs,
+// not a pre-joined string) — see
+// https://github.com/joe-bell/cva/releases/tag/v1.0.0-beta.9
 export const { cva, cx } = defineConfig({
-  hooks: {
-    onComplete: (className) => twMerge(className),
-  },
+  cx: (...inputs) => twMerge(clsx(inputs)),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ catalogs:
     '@tailwindcss/vite':
       specifier: ^4.3.3
       version: 4.3.3
+    clsx:
+      specifier: ^2.1.1
+      version: 2.1.1
     tailwind-merge:
       specifier: ^3.6.0
       version: 3.6.0
@@ -298,9 +301,12 @@ importers:
       '@internationalized/date':
         specifier: ^3.12.4
         version: 3.12.4
+      clsx:
+        specifier: catalog:tailwind
+        version: 2.1.1
       cva:
-        specifier: 1.0.0-beta.8
-        version: 1.0.0-beta.8(typescript@7.0.2)
+        specifier: 1.0.0-beta.9
+        version: 1.0.0-beta.9(typescript@7.0.2)
       lucide-react:
         specifier: catalog:icons
         version: 1.43.0(react@19.2.8)
@@ -2397,10 +2403,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  cva@1.0.0-beta.8:
-    resolution: {integrity: sha512-d77ya4Ga/0Mzam9X99EVpbg9V+sfyEni7cM8Hu42GFAe0GtchBO1CUA803XPLRAYtg1VvVyUHt8z4kQycp2yug==}
+  cva@1.0.0-beta.9:
+    resolution: {integrity: sha512-hSiw3E2Z5IBAUhqSBcH32Zu5A73oZnCXCb7h5vWRs2QTMVLnqtj1dUGYVRcT7p0nqEJOJJ7jT0EvqkSA35Z5ZA==}
     peerDependencies:
-      typescript: '>= 4.5.5'
+      typescript: '>= 6.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4871,7 +4877,7 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cva@1.0.0-beta.8(typescript@7.0.2):
+  cva@1.0.0-beta.9(typescript@7.0.2):
     dependencies:
       clsx: 2.1.1
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalogs:
     react-aria-components: ^1.21.1
   tailwind:
     "@tailwindcss/vite": ^4.3.3
+    clsx: ^2.1.1
     tailwind-merge: ^3.6.0
     "tailwindcss": ^4.3.3
   types:


### PR DESCRIPTION
## Was

`cva` 1.0.0-beta.8 → 1.0.0-beta.9 in `packages/ui` (die einzige Stelle, die es nutzt).

## Deprecation-Check (wie gewünscht vorab verifiziert)

Zwei Deprecations aus dem [Changelog](https://github.com/joe-bell/cva/releases/tag/v1.0.0-beta.9) treffen unsere einzige Nutzung ([`packages/ui/src/lib/cva.ts`](../blob/main/packages/ui/src/lib/cva.ts)) direkt:

1. `defineConfig` von `"cva"` → jetzt `"cva/config"`
2. `hooks.onComplete` (unser bisheriger twMerge-Hook) → ersetzt durch die neue `cx`-Option

Beides "still works but deprecated" — kein Hard-Break, aber gleich sauber migriert statt nur die Version zu bumpen:

```ts
import { clsx } from "clsx";
import { defineConfig } from "cva/config";
import { twMerge } from "tailwind-merge";

export const { cva, cx } = defineConfig({
  cx: (...inputs) => twMerge(clsx(inputs)),
});
```

`cx` übernimmt jetzt Join **und** Merge zusammen (rohe Inputs statt fertig-gejointem String) — daher `clsx` jetzt explizit als Dependency (vorher nur transitiv über `cva`, unter pnpms strikter Auflösung nicht direkt importierbar). In den `tailwind`-Katalog gepackt, neben `tailwind-merge`.

## Verifiziert

Typecheck (`web` + `ui`), `pnpm check`, alle 48 Domain-Tests grün, und ein manueller Durchgang durch den Manager — die `className`-Override-Mechanik (z.B. die Hit-Area-Caps aus PR #26) löst nach der Migration exakt gleich auf (live nachgemessen, identische Pixelwerte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)