### PR TITLE
Replace clsx + tailwind-merge with cn

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,10 +13,9 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.4",
-    "clsx": "catalog:tailwind",
+    "cn": "catalog:tailwind",
     "cva": "1.0.0-beta.9",
-    "lucide-react": "catalog:icons",
-    "tailwind-merge": "catalog:tailwind"
+    "lucide-react": "catalog:icons"
   },
   "devDependencies": {
     "@tipprunde/theme": "workspace:*",

--- a/packages/ui/src/lib/compose.ts
+++ b/packages/ui/src/lib/compose.ts
@@ -1,13 +1,13 @@
+import { cn } from "cn";
 import { composeRenderProps } from "react-aria-components";
-import { twMerge } from "tailwind-merge";
 
 /**
  * Merge a RAC render-prop className (string or function) with default Tailwind
- * classes. Consumer classes win via twMerge.
+ * classes. Consumer classes win via cn.
  */
 export function composeTailwindRenderProps<T>(
   className: string | ((v: T) => string) | undefined,
   tw: string,
 ): string | ((v: T) => string) {
-  return composeRenderProps(className, (cls) => twMerge(tw, cls));
+  return composeRenderProps(className, (cls) => cn(tw, cls));
 }

--- a/packages/ui/src/lib/cva.ts
+++ b/packages/ui/src/lib/cva.ts
@@ -1,11 +1,9 @@
-import { clsx } from "clsx";
+import { cn } from "cn";
 import { defineConfig } from "cva/config";
-import { twMerge } from "tailwind-merge";
 
-// `hooks.onComplete` is deprecated as of cva@1.0.0-beta.9 in favor of `cx`,
-// which now owns the whole join-then-merge step (it receives the raw inputs,
-// not a pre-joined string) — see
-// https://github.com/joe-bell/cva/releases/tag/v1.0.0-beta.9
-export const { cva, cx } = defineConfig({
-  cx: (...inputs) => twMerge(clsx(inputs)),
-});
+// cn (shadcn's package, not clsx+tailwind-merge) already has the exact
+// signature cx wants — join then merge, raw inputs in, one string out — so
+// no wrapper needed. See
+// https://github.com/joe-bell/cva/releases/tag/v1.0.0-beta.9 for why `cx`
+// replaces the old `hooks.onComplete`.
+export const { cva, cx } = defineConfig({ cx: cn });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,12 +141,9 @@ catalogs:
     '@tailwindcss/vite':
       specifier: ^4.3.3
       version: 4.3.3
-    clsx:
-      specifier: ^2.1.1
-      version: 2.1.1
-    tailwind-merge:
-      specifier: ^3.6.0
-      version: 3.6.0
+    cn:
+      specifier: ^0.2.6
+      version: 0.2.6
     tailwindcss:
       specifier: ^4.3.3
       version: 4.3.3
@@ -301,9 +298,9 @@ importers:
       '@internationalized/date':
         specifier: ^3.12.4
         version: 3.12.4
-      clsx:
+      cn:
         specifier: catalog:tailwind
-        version: 2.1.1
+        version: 0.2.6
       cva:
         specifier: 1.0.0-beta.9
         version: 1.0.0-beta.9(typescript@7.0.2)
@@ -313,9 +310,6 @@ importers:
       react:
         specifier: '*'
         version: 19.2.8
-      tailwind-merge:
-        specifier: catalog:tailwind
-        version: 3.6.0
     devDependencies:
       '@tipprunde/theme':
         specifier: workspace:*
@@ -2372,6 +2366,11 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cn@0.2.6:
+    resolution: {integrity: sha512-+i4L0zUGgRcEnhsxueVrP7iBGxBx5iD0WOTYg1MwFEu2ZyCmH5Ov2V1cul2Ht5UchRQQgftCf4be/RxspuW6QQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -3174,9 +3173,6 @@ packages:
   svelte@5.56.2:
     resolution: {integrity: sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==}
     engines: {node: '>=18'}
-
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -4841,6 +4837,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cn@0.2.6: {}
+
   commander@2.20.3:
     optional: true
 
@@ -5577,8 +5575,6 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
     optional: true
-
-  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,8 +25,7 @@ catalogs:
     react-aria-components: ^1.21.1
   tailwind:
     "@tailwindcss/vite": ^4.3.3
-    clsx: ^2.1.1
-    tailwind-merge: ^3.6.0
+    cn: ^0.2.6
     "tailwindcss": ^4.3.3
   types:
     "@types/node": ^26.5.0


### PR DESCRIPTION
**Gestackt auf #28** (braucht dessen `cx`-Config) — erst dort mergen, dann hier.

## Was

`cn` (shadcns Paket, direkt in cvas eigener beta.9-Installationsdoku erwähnt) ist ein Drop-in-Replacement für die `clsx` + `tailwind-merge`-Kombi: gleiches Join-dann-Merge-Verhalten, null Dependencies, kleiner, schneller. Ganz neu (0.2.6, wenige Tage alt), aber aus einer Quelle, der wir für so eine Grundbaustein-Aufgabe vertrauen.

- [`cva.ts`](../blob/chore/cn-package/packages/ui/src/lib/cva.ts): `cn` hat schon exakt die Signatur, die `cx` will — der `(...inputs) => twMerge(clsx(inputs))`-Wrapper aus der beta.9-Migration ist weg, `cx` ist jetzt einfach `cn`.
- [`compose.ts`](../blob/chore/cn-package/packages/ui/src/lib/compose.ts): der RAC-Render-Props-Merge (`composeTailwindRenderProps`) nutzte `twMerge` direkt, gar nicht über `cva` — auch dort auf `cn` umgestellt, damit `tailwind-merge`/`clsx` komplett aus dem Tree fallen statt für eine Stelle hängen zu bleiben.

## Verifiziert

Typecheck (`web` + `ui`), `pnpm check`, alle 48 Domain-Tests grün, und ein Browser-Durchgang — der `/spieler`-Hit-Area-Override erzeugt byte-identische Klassen-Strings wie vorher, der RAC-Fokus-Ring im Regelwerk-Dialog (der `composeTailwindRenderProps`-Pfad) rendert weiterhin korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)