### PR TITLE
Let a championship be published independently of its state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.10.1
+
+[compare changes](https://github.com/haus23/tipprunde/compare/v1.10.0...v1.10.1)
+
+### 🩹 Fixes
+
+- **web:** Let a championship be published independently of its state ([1537c60](https://github.com/haus23/tipprunde/commit/1537c60))
+
+### 🏡 Chore
+
+- Bump react, react-dom, valibot, @types/node, @types/react(-dom) ([b4197d2](https://github.com/haus23/tipprunde/commit/b4197d2))
+- **ui:** Bump cva to 1.0.0-beta.9, migrate off deprecated config ([d5da4cd](https://github.com/haus23/tipprunde/commit/d5da4cd))
+- **ui:** Replace clsx + tailwind-merge with cn ([0142334](https://github.com/haus23/tipprunde/commit/0142334))
+
 ## v1.10.0
 
 [compare changes](https://github.com/haus23/tipprunde/compare/v1.9.0...v1.10.0)

--- a/apps/web/app/routes/manager/championship/index.tsx
+++ b/apps/web/app/routes/manager/championship/index.tsx
@@ -284,11 +284,13 @@ export async function action({ request, context }: Route.ActionArgs) {
     return null;
   }
 
-  // Championship flag toggle — when completed, only the `completed` switch
-  // itself may change (it is the unlock control); other flags stay locked.
+  // Championship flag toggle. A completed championship freezes its data, but
+  // two switches stay operable: `completed` itself (the unlock control) and
+  // `published`, which is visibility only and deliberately depends on nothing
+  // — see the switch block for the reasoning.
   const field = v.parse(flagField, formData.get("field"));
   const value = formData.get("value") === "true";
-  if (locked && field !== "completed") return null;
+  if (locked && field !== "completed" && field !== "published") return null;
   await db
     .update(championships)
     .set({ [field]: value })
@@ -516,12 +518,19 @@ export default function ChampionshipIndex({ loaderData }: Route.ComponentProps) 
     championship.extraQuestionPointsPublished,
   );
 
-  // Dependency chain: published → extraQuestionPointsPublished (if present) → completed
-  // Turning completed on disables all other switches
-  const publishedDisabled = isFlagPending || completed;
-  const extraQuestionsDisabled = isFlagPending || !published || completed;
-  const completedDisabled =
-    isFlagPending || !published || (hasExtraQuestions && !extraQuestionPointsPublished);
+  // `published` is visibility and nothing else, so it hangs off nothing: a
+  // legacy championship is entered and finished long before it should show up
+  // on the front page, and the release is timed deliberately. It stays
+  // togglable in both directions whether or not the championship is completed.
+  //
+  // One real dependency is left: a championship with extra questions cannot be
+  // completed while their points are unpublished, because completing freezes
+  // them. The same invariant is why the extra-points switch locks once
+  // completed — otherwise the state it was completed under could be revoked
+  // underneath it. Uncomplete first, then unpublish the points.
+  const publishedDisabled = isFlagPending;
+  const extraQuestionsDisabled = isFlagPending || completed;
+  const completedDisabled = isFlagPending || (hasExtraQuestions && !extraQuestionPointsPublished);
 
   return (
     <div className="space-y-6">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipprunde",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Haus23 Tipprunde",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Das Problem

Veröffentlichen ist reine Sichtbarkeit — hing aber an der ganzen Kette:

```
publishedDisabled      = isFlagPending || completed
extraQuestionsDisabled = isFlagPending || !published || completed
completedDisabled      = isFlagPending || !published || (hasExtraQuestions && !extraQuestionPointsPublished)
```

Das steht dem Erfassen der Historie im Weg. Ein Turnier wird importiert, die Zusatzfragen werden eingetragen, es wird abgeschlossen und geprüft — alles lange **bevor** es auf der Startseite erscheinen soll, weil die Saisons einzeln und mit ein paar Tagen Abstand an die Tipprunde ausgerollt werden. Bisher musste man dafür erst veröffentlichen, und um es danach wieder offline zu nehmen, das Turnier **ent-abschließen** — der völlig falsche Hebel.

## Die Änderung

```
publishedDisabled      = isFlagPending
extraQuestionsDisabled = isFlagPending || completed
completedDisabled      = isFlagPending || (hasExtraQuestions && !extraQuestionPointsPublished)
```

`published` hängt jetzt an nichts, in beide Richtungen, und Abschließen setzt es nicht mehr voraus.

**Was bleibt**, weil es echte Bedeutung trägt: ein Turnier mit Zusatzfragen kann nicht abgeschlossen werden, solange deren Punkte unveröffentlicht sind — und der Zusatzfragen-Schalter sperrt, sobald abgeschlossen ist. Der Zustand, unter dem abgeschlossen wurde, soll nicht nachträglich entziehbar sein.

Der Server-Wächter musste mitziehen: er ließ bei `locked` nur `completed` durch, ein freigeschalteter Schalter wäre sonst still ignoriert worden.

## Neuer Zustand `completed && !published`

War über die UI vorher unerreichbar, deshalb geprüft, dass nichts das Gegenteil annimmt:

- `getPublishedChampionship()` nimmt das neueste **veröffentlichte** Turnier und hält ausdrücklich fest, dass `completed` dabei keine Rolle spielt
- Archiv-Liste, ewige Tabelle und Slug-Auflösung filtern durchgehend auf `published`

## Verifiziert

Auf Dev am frisch importierten Turnier 11 (Hinrunde 2006/07) durchgespielt:

| Schritt | Ergebnis |
|---|---|
| Zusatzfragenpunkte aus → „Abgeschlossen" | gesperrt ✅ |
| Zusatzfragenpunkte an → „Abgeschlossen" | frei ✅ |
| Abgeschlossen an → Zusatzfragenpunkte | sperrt ✅ |
| Abgeschlossen an → „Veröffentlicht" | **bleibt frei** ✅ |
| Veröffentlichen bei `completed` | DB: `published=1, completed=1` ✅ |
| Ent-Veröffentlichen bei `completed` | DB: `published=0, completed=1` ✅ |
| Startseite währenddessen | fällt auf `rr0506` zurück ✅ |

Typecheck und `pnpm check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)